### PR TITLE
Spring REST Docs + Swagger UI 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,4 @@ out/
 # docker/
 
 ### RestDocs ###
-# src/main/resources/static/docs/
+src/main/resources/static/docs/

--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.4'
     id 'org.ec4j.editorconfig' version '0.0.2'
     id 'checkstyle'
+    id 'com.epages.restdocs-api-spec' version '0.18.2'
+    id 'org.hidetake.swagger.generator' version '2.18.2'
 }
 
 compileJava.options.encoding = 'UTF-8'
@@ -45,14 +47,39 @@ dependencies {
     /* Security */
     implementation 'org.springframework.boot:spring-boot-starter-security:3.2.4'
     testImplementation 'org.springframework.security:spring-security-test:6.2.3'
+
+    /* Spring Rest Docs */
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc:3.0.1'
+    testImplementation "com.epages:restdocs-api-spec-mockmvc:0.18.2"
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
 }
 
-tasks.named('test') {
+test {
     useJUnitPlatform()
 }
 
+
+def localStaticDocsPath = "${rootDir}/src/main/resources/static/docs/"
+def buildStaticDocsPath = "${rootDir}/build/resources/main/static/docs/"
+def fileNamePrefix = 'open-api-3.0.1'
+def fileFormat = 'yaml'
+def swaggerFileName = "${fileNamePrefix}.${fileFormat}"
+
+openapi3 {
+    servers = [
+            { url = "http://localhost:8080/" },
+    ]
+    title = "Colla API 문서"
+    description = "Spring REST Docs with SwaggerUI."
+    version = "0.1.0"
+    format = fileFormat
+    outputFileNamePrefix = fileNamePrefix
+    outputDirectory = buildStaticDocsPath
+}
+
 editorconfig {
-    excludes = ['build']
+    excludes = ['build', 'node_modules', '.husky', '**/open-api-3.0.1.yaml']
 }
 
 check.dependsOn editorconfigCheck
@@ -68,3 +95,40 @@ checkstyle {
 
 checkstyleMain.source = fileTree('src/main/java')
 
+tasks.register('ensureStaticFolder') {
+    doFirst {
+        def staticFolder = file("${projectDir}/src/main/resources/static")
+        if (!staticFolder.exists()) {
+            staticFolder.mkdirs()
+        }
+    }
+}
+processResources.dependsOn('ensureStaticFolder')
+
+bootJar {
+    dependsOn("openapi3")
+
+    doFirst {
+        def swaggerUIFile = file("${openapi3.outputDirectory}${swaggerFileName}")
+        def securitySchemesContent = "  securitySchemes:\n" +                     \
+                                                         "    APIKey:\n" +                     \
+                                                         "      type: apiKey\n" +                     \
+                                                         "      name: Authorization\n" +                     \
+                                                         "      in: header\n" +                    \
+                                                         "security:\n" +
+                "  - APIKey: []  # Apply the security scheme here"
+
+        swaggerUIFile.append securitySchemesContent
+    }
+    doLast {
+        delete "${localStaticDocsPath}${swaggerFileName}"
+        copy {
+            from "${openapi3.outputDirectory}${swaggerFileName}"
+            into "${localStaticDocsPath}"
+        }
+    }
+}
+
+jar {
+    enabled = false
+}

--- a/build.gradle
+++ b/build.gradle
@@ -110,13 +110,13 @@ bootJar {
 
     doFirst {
         def swaggerUIFile = file("${openapi3.outputDirectory}${swaggerFileName}")
-        def securitySchemesContent = "  securitySchemes:\n" +                     \
-                                                         "    APIKey:\n" +                     \
-                                                         "      type: apiKey\n" +                     \
-                                                         "      name: Authorization\n" +                     \
-                                                         "      in: header\n" +                    \
-                                                         "security:\n" +
-                "  - APIKey: []  # Apply the security scheme here"
+        def securitySchemesContent = "  securitySchemes:\n" +
+                "    APIKey:\n" +
+                "      type: apiKey\n" +
+                "      name: Authorization\n" +
+                "      in: header\n" +
+                "security:\n" +
+                "  - APIKey: []  # Apply the security scheme here\n"
 
         swaggerUIFile.append securitySchemesContent
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=colla-backend

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  application:
+    name:
+      colla-backend
+
+springdoc:
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    url: /docs/open-api-3.0.1.yaml
+    path: /swagger

--- a/src/test/java/one/colla/global/RestDocsControllerTestBase.java
+++ b/src/test/java/one/colla/global/RestDocsControllerTestBase.java
@@ -1,0 +1,40 @@
+package one.colla.global;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import one.colla.global.config.RestDocsConfiguration;
+
+@Import(RestDocsConfiguration.class)
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class RestDocsControllerTestBase {
+
+	@Autowired
+	protected RestDocumentationResultHandler restDocs;
+
+	@Autowired
+	protected MockMvc mockMvc;
+
+	@BeforeEach
+	void setUp(
+		final WebApplicationContext context,
+		final RestDocumentationContextProvider restDocumentation) {
+		this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+			.apply(documentationConfiguration(restDocumentation))
+			.alwaysDo(restDocs)
+			.addFilters(new CharacterEncodingFilter("UTF-8", true))
+			.build();
+	}
+
+}

--- a/src/test/java/one/colla/global/TemporaryRestDocsControllerTest.java
+++ b/src/test/java/one/colla/global/TemporaryRestDocsControllerTest.java
@@ -1,0 +1,7 @@
+package one.colla.global;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@WebMvcTest()
+public abstract class TemporaryRestDocsControllerTest extends RestDocsControllerTestBase {
+}

--- a/src/test/java/one/colla/global/config/RestDocsConfiguration.java
+++ b/src/test/java/one/colla/global/config/RestDocsConfiguration.java
@@ -1,0 +1,34 @@
+package one.colla.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
+
+@Configuration
+public class RestDocsConfiguration {
+
+	@Bean
+	public RestDocumentationResultHandler write() {
+		return MockMvcRestDocumentationWrapper.document(
+			"{class-name}/{method-name}",
+			Preprocessors.preprocessRequest(
+				Preprocessors.modifyHeaders()
+					.remove("Content-Length")
+					.remove("Host"),
+				Preprocessors.prettyPrint()
+			),
+			Preprocessors.preprocessResponse(
+				Preprocessors.modifyHeaders()
+					.remove("Transfer-Encoding")
+					.remove("Date")
+					.remove("Keep")
+					.remove("Connection"),
+				Preprocessors.prettyPrint()
+			)
+		);
+	}
+
+}


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-backend/issues/3

## ✨ PR 세부 내용

- Rest Docs + Swagger UI 관련 `build.gradle` 및 `Configuration` 작성
- 모든 Controller Test를 위한 `RestDocsControllerTestBase` 작성
- Swagger UI 노출을 위한 `application.yml` 작성
- 첫 컨트롤러 테스트 작성 시 `TemporaryRestDocsControllerTest` 삭제 


**>  삭제 이유**

1. `RestDocsControllerTestBase`에 `@Autowired`가  `@WebMvcTest`가 등록되어 있지 않으면 의존성 주입 에러가 발생
2. 프로젝트 초기 설정 중에는 `RestDocsControllerTestBase`를 상속 받는 어떠한 Test도 존재하지 않아서 `@WebMvcTest` 등록이 안됨 
3. 따라서 오류 방지를 위해 추가한 `TemporaryRestDocsControllerTest` 삭제
<br>

**>  `RestDocsControllerTestBase`에 `@WebMvcTest`를 등록하지 않는 이유**

1. `RestDocsControllerTestBase`에 해당 어노테이션을 사용하려면 `@WebMvcTest()` 형태로 사용해야 함
2. 공식 문서를 확인해 보면 빈 괄호는 모든 Controller Bean을 ApplicationContext에 추가하는 설정
4. 단 하나의 Controller Test를 진행하려고 해도 모든 Controller Bean 로드하게 되어 성능 이슈가 발생
<br>


## 📸 스크린샷

-  RestDocsControllerTestBase:
<img width="828" alt="스크린샷 2024-04-13 오전 1 58 18" src="https://github.com/98OO/colla-backend/assets/67590577/98f5cbfe-e709-419a-ac45-3481ef3d0cfd">   
<br><br>


-  아래 TemporaryRestDocsControllerTest 삭제:
<img width="1000" alt="스크린샷 2024-04-13 오전 1 53 01" src="https://github.com/98OO/colla-backend/assets/67590577/e9081db0-5b76-44a7-a9e6-70a9de7145e6">



## ✅ 리뷰 요구사항

- 설정 관련 및 궁금한 점이 있다면 연락주세요!
- build.gradle에 파일 경로를 변수로 연결해봤는데 오히려 가독성이 떨어지는 것 같은 느낌이 드는데 의견 부탁드립니다!
1. `def swaggerUIFile = file("${openapi3.outputDirectory}${swaggerFileName}")` (변수로 연결)
2. `def swaggerUIFile = file("/build/resources/main/static/docs/open-api-3.0.1.yaml")` 
