### PR TITLE
데이터베이스 구축을 위한 Docker 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,9 @@ out/
 ### application*.yml ###
 # src/main/resources/*.yml
 
-### docker ###
-# docker/
+##### docker ###
+docker/*
+!docker/*.yml
 
 ### RestDocs ###
 src/main/resources/static/docs/

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ out/
 ### application*.yml ###
 # src/main/resources/*.yml
 
-##### docker ###
+### docker ###
 docker/*
 !docker/*.yml
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+services:
+  mysql8:
+    image: mysql:8.0.28
+    platform: linux/x86_64
+    container_name: colla_mysql
+    restart: always
+    ports:
+      - "${MYSQL_HOST_PORT}:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: colla
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      TZ: Asia/Seoul
+    volumes:
+      - ./db/mysql/data:/var/lib/mysql
+      - ./db/mysql/config:/etc/mysql/conf.d
+      - ./db/mysql/init:/docker-entrypoint-initdb.d
+
+  redis:
+    image: redis:alpine
+    command: redis-server --port 6379
+    container_name: colla_redis
+    hostname: root
+    labels:
+      - "name=redis"
+      - "mode=standalone"
+    ports:
+      - "${REDIS_HOST_PORT}:6379"
+    environment:
+      TZ: Asia/Seoul


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-backend/issues/9

## ✨ PR 세부 내용
**개발 환경 및 프로덕션 환경에서 사용할 데이터베이스들을 도커라이징 합니다.**
- MySQL 볼륨 파일 gitignore에 등록
- MySQL 구성을 위한 Docker Compose 파일 작성
- Redis 구성을 위한 Docker Compose 파일 작성
- 정상 Compose Up 작동 확인

<br/>

**Docker Compose 실행 방법**
실행 전 환경변수 지정 필요
```shell
cd docker
MYSQL_HOST_PORT={} MYSQL_ROOT_PASSWORD="{}" MYSQL_USER="{}" MYSQL_PASSWORD="{}" REDIS_HOST_PORT={} docker-compose up -d
```
전체 명령어는 프로젝트 Notion에 명시해 두었습니다.

