### PR TITLE
공통 응답 및 에러 처리 작성 #14

### DIFF
--- a/src/main/java/one/colla/common/presentation/ApiResponse.java
+++ b/src/main/java/one/colla/common/presentation/ApiResponse.java
@@ -2,10 +2,8 @@ package one.colla.common.presentation;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import one.colla.global.exception.CommonException;
 
-@Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ApiResponse<T> {
 

--- a/src/main/java/one/colla/common/presentation/ApiResponse.java
+++ b/src/main/java/one/colla/common/presentation/ApiResponse.java
@@ -1,0 +1,25 @@
+package one.colla.common.presentation;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import one.colla.global.exception.CommonException;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponse<T> {
+
+	public static final int SUCCESS_CODE = 20000;
+
+	private final int code;
+	private final T content;
+	private final String message;
+
+	public static <T> ApiResponse<T> createSuccessResponse(T content) {
+		return new ApiResponse<>(SUCCESS_CODE, content, null);
+	}
+
+	public static <T> ApiResponse<T> createErrorResponse(CommonException ex) {
+		return new ApiResponse<>(ex.getErrorCode(), null, ex.getMessage());
+	}
+}

--- a/src/main/java/one/colla/common/presentation/ApiResponse.java
+++ b/src/main/java/one/colla/common/presentation/ApiResponse.java
@@ -1,5 +1,7 @@
 package one.colla.common.presentation;
 
+import org.springframework.http.ResponseEntity;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import one.colla.global.exception.CommonException;
@@ -19,5 +21,11 @@ public class ApiResponse<T> {
 
 	public static <T> ApiResponse<T> createErrorResponse(CommonException ex) {
 		return new ApiResponse<>(ex.getErrorCode(), null, ex.getMessage());
+	}
+
+	public static ResponseEntity<ApiResponse<?>> createErrorResponseEntity(CommonException ex) {
+		return ResponseEntity
+			.status(ex.getHttpStatus())
+			.body(createErrorResponse(ex));
 	}
 }

--- a/src/main/java/one/colla/global/exception/CommonException.java
+++ b/src/main/java/one/colla/global/exception/CommonException.java
@@ -1,0 +1,19 @@
+package one.colla.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+
+@Getter
+public class CommonException extends RuntimeException {
+
+	private final HttpStatus httpStatus;
+	private final int errorCode;
+	private final String message;
+
+	public CommonException(ExceptionCode ex) {
+		this.httpStatus = ex.getHttpStatus();
+		this.errorCode = ex.getErrorCode();
+		this.message = ex.getMessage();
+	}
+}

--- a/src/main/java/one/colla/global/exception/ExceptionCode.java
+++ b/src/main/java/one/colla/global/exception/ExceptionCode.java
@@ -1,0 +1,18 @@
+package one.colla.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ExceptionCode {
+
+	/* 500_INTERNAL_SERVER_ERROR */
+	UNEXPECTED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 50001, "서버 에러 입니다.");
+
+	private final HttpStatus httpStatus;
+	private final int errorCode;
+	private final String message;
+}

--- a/src/main/java/one/colla/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/one/colla/global/exception/GlobalExceptionHandler.java
@@ -11,8 +11,6 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler(CommonException.class)
 	public ResponseEntity<ApiResponse<?>> handleGlobalException(CommonException ex) {
-		return ResponseEntity
-			.status(ex.getHttpStatus())
-			.body(ApiResponse.createErrorResponse(ex));
+		return ApiResponse.createErrorResponseEntity(ex);
 	}
 }

--- a/src/main/java/one/colla/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/one/colla/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package one.colla.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import one.colla.common.presentation.ApiResponse;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+	@ExceptionHandler(CommonException.class)
+	public ResponseEntity<ApiResponse<?>> handleGlobalException(CommonException ex) {
+		return ResponseEntity
+			.status(ex.getHttpStatus())
+			.body(ApiResponse.createErrorResponse(ex));
+	}
+}

--- a/src/test/java/one/colla/common/presentation/ApiResponseTest.java
+++ b/src/test/java/one/colla/common/presentation/ApiResponseTest.java
@@ -1,0 +1,49 @@
+package one.colla.common.presentation;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import one.colla.global.exception.CommonException;
+import one.colla.global.exception.ExceptionCode;
+
+class ApiResponseTest {
+
+	private static final int SUCCESS_CODE = 20000;
+
+	@DisplayName("성공 응답을 생성하면 code값은 20000이고, content는 주어진 값이며, message는 null이다.")
+	@Test
+	void createSuccessResponse() {
+
+		//given
+		Object content = Map.of();
+
+		//when
+		ApiResponse<?> response = ApiResponse.createSuccessResponse(content);
+
+		//then
+		assertThat(response.getCode()).isEqualTo(SUCCESS_CODE);
+		assertThat(response.getContent()).isEqualTo(content);
+		assertThat(response.getMessage()).isEqualTo(null);
+	}
+
+	@Test
+	@DisplayName("에러 응답을 생성하면 code는 에러 코드이고, content는 null이며, message는 에러 메시지이다.")
+	void createErrorResponse() {
+
+		// given
+		ExceptionCode serverError = ExceptionCode.UNEXPECTED_ERROR;
+		CommonException ex = new CommonException(serverError);
+
+		// when
+		ApiResponse<?> response = ApiResponse.createErrorResponse(ex);
+
+		// then
+		assertThat(response.getCode()).isEqualTo(serverError.getErrorCode());
+		assertThat(response.getContent()).isEqualTo(null);
+		assertThat(response.getMessage()).isEqualTo(serverError.getMessage());
+	}
+}

--- a/src/test/java/one/colla/common/presentation/ApiResponseTest.java
+++ b/src/test/java/one/colla/common/presentation/ApiResponseTest.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
 
 import one.colla.global.exception.CommonException;
 import one.colla.global.exception.ExceptionCode;
@@ -26,9 +27,14 @@ class ApiResponseTest {
 		ApiResponse<?> response = ApiResponse.createSuccessResponse(content);
 
 		// then
-		assertThat(getField(response, "code")).isEqualTo(SUCCESS_CODE);
-		assertThat(getField(response, "content")).isEqualTo(content);
-		assertThat(getField(response, "message")).isNull();
+		assertThat(getField(response, "code"))
+			.isEqualTo(SUCCESS_CODE);
+
+		assertThat(getField(response, "content"))
+			.isEqualTo(content);
+
+		assertThat(getField(response, "message"))
+			.isNull();
 	}
 
 	@DisplayName("에러 응답을 생성하면 code는 에러 코드이고, content는 null이며, message는 에러 메시지이다.")
@@ -43,8 +49,40 @@ class ApiResponseTest {
 		ApiResponse<?> response = ApiResponse.createErrorResponse(ex);
 
 		// then
-		assertThat(getField(response, "code")).isEqualTo(serverError.getErrorCode());
-		assertThat(getField(response, "content")).isNull();
-		assertThat(getField(response, "message")).isEqualTo(serverError.getMessage());
+		assertThat(getField(response, "code"))
+			.isEqualTo(serverError.getErrorCode());
+
+		assertThat(getField(response, "content"))
+			.isNull();
+
+		assertThat(getField(response, "message"))
+			.isEqualTo(serverError.getMessage());
+	}
+
+	@DisplayName("에러 응답 엔티티 생성 시, HTTP 상태 코드와 에러 메시지가 적절하게 반환된다.")
+	@Test
+	void createErrorResponseEntityUsingReflection() {
+		// given
+		ExceptionCode serverError = ExceptionCode.UNEXPECTED_ERROR;
+		CommonException ex = new CommonException(serverError);
+
+		// when
+		ResponseEntity<ApiResponse<?>> responseEntity = ApiResponse.createErrorResponseEntity(ex);
+
+		// then
+		assertThat(responseEntity.getStatusCode())
+			.isEqualTo(serverError.getHttpStatus());
+
+		assertThat(responseEntity.getBody())
+			.isNotNull();
+
+		assertThat(getField(responseEntity.getBody(), "code"))
+			.isEqualTo(serverError.getErrorCode());
+
+		assertThat(getField(responseEntity.getBody(), "content"))
+			.isNull();
+
+		assertThat(getField(responseEntity.getBody(), "message"))
+			.isEqualTo(serverError.getMessage());
 	}
 }

--- a/src/test/java/one/colla/common/presentation/ApiResponseTest.java
+++ b/src/test/java/one/colla/common/presentation/ApiResponseTest.java
@@ -1,6 +1,7 @@
 package one.colla.common.presentation;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.util.ReflectionTestUtils.*;
 
 import java.util.Map;
 
@@ -18,20 +19,20 @@ class ApiResponseTest {
 	@Test
 	void createSuccessResponse() {
 
-		//given
+		// given
 		Object content = Map.of();
 
-		//when
+		// when
 		ApiResponse<?> response = ApiResponse.createSuccessResponse(content);
 
-		//then
-		assertThat(response.getCode()).isEqualTo(SUCCESS_CODE);
-		assertThat(response.getContent()).isEqualTo(content);
-		assertThat(response.getMessage()).isEqualTo(null);
+		// then
+		assertThat(getField(response, "code")).isEqualTo(SUCCESS_CODE);
+		assertThat(getField(response, "content")).isEqualTo(content);
+		assertThat(getField(response, "message")).isNull();
 	}
 
-	@Test
 	@DisplayName("에러 응답을 생성하면 code는 에러 코드이고, content는 null이며, message는 에러 메시지이다.")
+	@Test
 	void createErrorResponse() {
 
 		// given
@@ -42,8 +43,8 @@ class ApiResponseTest {
 		ApiResponse<?> response = ApiResponse.createErrorResponse(ex);
 
 		// then
-		assertThat(response.getCode()).isEqualTo(serverError.getErrorCode());
-		assertThat(response.getContent()).isEqualTo(null);
-		assertThat(response.getMessage()).isEqualTo(serverError.getMessage());
+		assertThat(getField(response, "code")).isEqualTo(serverError.getErrorCode());
+		assertThat(getField(response, "content")).isNull();
+		assertThat(getField(response, "message")).isEqualTo(serverError.getMessage());
 	}
 }


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-backend/issues/14

## ✨ PR 세부 내용

**공통 성공/에러 응답 작성을 위한 Api Response 작성** 
- 성공 응답 시 
  - code는 `20000`
  - content `해당 요청에 대응하는 응답`
  - message는 `null`
- 에러 응답 시
  -  code는 `설계한 에러코드`
  - content는 `null`
  - message는 `해당 에러 사유`

**예외 발생 시 Error Response 응답** 
- `CommonException`이 발생하면 `GlobalExceptionHandler`에서 캐치하여 오류를 발생시키지 않고 응답 메시지를 만들어 
클라이언트에게 전달

## 📸 스크린샷
- 리뷰 요구사항에 작성한 상수
![스크린샷 2024-04-18 오전 1 02 54](https://github.com/98OO/colla-backend/assets/67590577/c4a817e6-4588-4988-b5d4-1ff26edcd5f7)

## ✅ 리뷰 요구사항
-  질문 있으시면 언제든 남겨주세요!
- `ApiResponse`에 `SUCCESS_CODE`를 상수로 만들어 사용했는데 다른 필드들과 헷갈리지 않는지 검토 부탁드릴게요!

