### PR TITLE
이메일 중복 검사 HTTP 메소드 변경

### DIFF
--- a/src/main/java/one/colla/auth/application/AuthService.java
+++ b/src/main/java/one/colla/auth/application/AuthService.java
@@ -13,7 +13,6 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import one.colla.auth.application.dto.JwtPair;
-import one.colla.auth.application.dto.request.DuplicationCheckRequest;
 import one.colla.auth.application.dto.request.LoginRequest;
 import one.colla.auth.application.dto.request.RegisterRequest;
 import one.colla.auth.application.dto.request.VerificationCheckRequest;
@@ -74,9 +73,9 @@ public class AuthService {
 	}
 
 	@Transactional(readOnly = true)
-	public void checkDuplication(DuplicationCheckRequest dto) {
-		isEmailDuplicated(dto.email());
-		log.info("이메일 중복 검사 - email: {}", dto.email());
+	public void checkDuplication(String email) {
+		isEmailDuplicated(email);
+		log.info("이메일 중복 검사 - email: {}", email);
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/one/colla/auth/presentation/AuthController.java
+++ b/src/main/java/one/colla/auth/presentation/AuthController.java
@@ -14,13 +14,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import one.colla.auth.application.AuthService;
 import one.colla.auth.application.dto.JwtPair;
-import one.colla.auth.application.dto.request.DuplicationCheckRequest;
 import one.colla.auth.application.dto.request.LoginRequest;
 import one.colla.auth.application.dto.request.RegisterRequest;
 import one.colla.auth.application.dto.request.VerificationCheckRequest;
@@ -59,10 +59,11 @@ public class AuthController {
 			.body(ApiResponse.createSuccessResponse(Map.of()));
 	}
 
-	@PostMapping("/mail/duplication")
+	@GetMapping("/mail/duplication")
 	@PreAuthorize("isAnonymous()")
-	public ResponseEntity<ApiResponse<Object>> checkDuplication(@RequestBody @Valid DuplicationCheckRequest request) {
-		authService.checkDuplication(request);
+	public ResponseEntity<ApiResponse<Object>> checkDuplication(
+		@RequestParam(value = "email", required = true) String email) {
+		authService.checkDuplication(email);
 		return ResponseEntity.ok()
 			.body(ApiResponse.createSuccessResponse(Map.of()));
 	}

--- a/src/test/java/one/colla/auth/application/AuthServiceTest.java
+++ b/src/test/java/one/colla/auth/application/AuthServiceTest.java
@@ -15,7 +15,6 @@ import org.mockito.Mock;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-import one.colla.auth.application.dto.request.DuplicationCheckRequest;
 import one.colla.auth.application.dto.request.RegisterRequest;
 import one.colla.auth.application.dto.request.VerificationCheckRequest;
 import one.colla.auth.application.dto.request.VerifyMailSendRequest;
@@ -137,11 +136,10 @@ class AuthServiceTest extends ServiceTest {
 
 			// given
 			final String UNIQUE_EMAIL = "unique@example.com";
-			DuplicationCheckRequest request = new DuplicationCheckRequest(UNIQUE_EMAIL);
 			given(userRepository.findByEmail(new Email(UNIQUE_EMAIL))).willReturn(Optional.empty());
 
 			// when & then
-			assertThatCode(() -> authService.checkDuplication(request)).doesNotThrowAnyException();
+			assertThatCode(() -> authService.checkDuplication(UNIQUE_EMAIL)).doesNotThrowAnyException();
 		}
 
 		@DisplayName("이메일이 중복 됐다면 중복 예외를 발생한다.")
@@ -150,11 +148,10 @@ class AuthServiceTest extends ServiceTest {
 
 			// given
 			final String DUPLICATED_EMAIL = "duplicated@example.com";
-			DuplicationCheckRequest request = new DuplicationCheckRequest(DUPLICATED_EMAIL);
 			given(userRepository.findByEmail(new Email(DUPLICATED_EMAIL))).willReturn(Optional.of(mock(User.class)));
 
 			// when & then
-			assertThatCode(() -> authService.checkDuplication(request))
+			assertThatCode(() -> authService.checkDuplication(DUPLICATED_EMAIL))
 				.isInstanceOf(CommonException.class)
 				.hasMessageContaining(DUPLICATED_USER_EMAIL.getMessage());
 		}

--- a/src/test/java/one/colla/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/one/colla/auth/presentation/AuthControllerTest.java
@@ -21,7 +21,6 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 
 import one.colla.auth.application.AuthService;
-import one.colla.auth.application.dto.request.DuplicationCheckRequest;
 import one.colla.auth.application.dto.request.RegisterRequest;
 import one.colla.auth.application.dto.request.VerificationCheckRequest;
 import one.colla.auth.application.dto.request.VerifyMailSendRequest;
@@ -195,26 +194,20 @@ class AuthControllerTest extends ControllerTest {
 	@Nested
 	@DisplayName("회원가입시 이메일 중복 검사 문서화")
 	class EmailDuplicationDocs {
-
+		final String QUESTION_MARK = "?";
 		final String EMAIL = "test@gmail.com";
 
 		@DisplayName("중복된 이메일이 존재하지 않으면 성공한다.")
 		@Test
 		void checkDuplication() throws Exception {
 
-			final DuplicationCheckRequest duplicationCheckRequest = new DuplicationCheckRequest(EMAIL);
-
-			mockMvc.perform(post("/api/v1/auth/mail/duplication")
-					.content(objectMapper.writeValueAsString(duplicationCheckRequest))
-					.contentType(MediaType.APPLICATION_JSON))
+			mockMvc.perform(get("/api/v1/auth/mail/duplication")
+					.queryParam("email", EMAIL))
 				.andExpect(status().isOk())
 				.andExpect(content().json(objectMapper.writeValueAsString(SUCCESS_RESPONSE)))
 				.andDo(restDocs.document(
 					resource(ResourceSnippetParameters.builder()
 						.tag("auth-controller")
-						.requestFields(
-							fieldWithPath("email").description("이메일").type(JsonFieldType.STRING)
-						)
 						.responseFields(
 							fieldWithPath("code").description("code").type(JsonFieldType.NUMBER),
 							fieldWithPath("content").description("content").type(JsonFieldType.OBJECT),
@@ -231,23 +224,17 @@ class AuthControllerTest extends ControllerTest {
 		@Test
 		void checkIsDuplicated() throws Exception {
 
-			final DuplicationCheckRequest duplicationCheckRequest = new DuplicationCheckRequest(EMAIL);
-
 			willThrow(new CommonException(ExceptionCode.DUPLICATED_USER_EMAIL)).given(authService)
 				.checkDuplication(any());
 
-			mockMvc.perform(post("/api/v1/auth/mail/duplication")
-					.content(objectMapper.writeValueAsString(duplicationCheckRequest))
-					.contentType(MediaType.APPLICATION_JSON))
+			mockMvc.perform(get("/api/v1/auth/mail/duplication")
+					.queryParam("email", EMAIL))
 				.andExpect(status().isConflict())
 				.andExpect(content().json(objectMapper.writeValueAsString(
 					ApiResponse.createErrorResponse(new CommonException(ExceptionCode.DUPLICATED_USER_EMAIL)))))
 				.andDo(restDocs.document(
 					resource(ResourceSnippetParameters.builder()
 						.tag("auth-controller")
-						.requestFields(
-							fieldWithPath("email").description("이메일").type(JsonFieldType.STRING)
-						)
 						.responseFields(
 							fieldWithPath("code").description("code").type(JsonFieldType.NUMBER),
 							fieldWithPath("content").description("content").type(JsonFieldType.NULL),


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-backend/issues/30

## ✨ PR 세부 내용

- 설계와 일치하지 않는 이메일 중복 검사 API의 HTTP 메소드 수정
- 서버에 리소스를 저장하지 않고 조회만 하는 api로 GET이 맞는것 같습니다!

## ✅ 리뷰 요구사항

- 질문 있으시면 댓글 남겨주세요!

