### PR TITLE
팀 스페이스 사용자 정보 관련

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,12 +150,12 @@ bootJar {
     doFirst {
         def swaggerUIFile = file("${openapi3.outputDirectory}${swaggerFileName}")
         def securitySchemesContent = "  securitySchemes:\n" +
-                "    APIKey:\n" +
-                "      type: apiKey\n" +
-                "      name: Authorization\n" +
-                "      in: header\n" +
+                "    BearerAuth:\n" +
+                "      type: http\n" +
+                "      scheme: bearer\n" +
+                "      bearerFormat: JWT\n" +
                 "security:\n" +
-                "  - APIKey: []  # Apply the security scheme here\n"
+                "   - BearerAuth: []  # Apply the Bearer token security scheme here\n"
 
         swaggerUIFile.append securitySchemesContent
     }

--- a/src/main/java/one/colla/auth/application/JwtService.java
+++ b/src/main/java/one/colla/auth/application/JwtService.java
@@ -35,9 +35,9 @@ public class JwtService {
 
 	public JwtPair createToken(User user) {
 		String accessToken = accessTokenProvider.generateToken(
-			AccessTokenClaim.of(user.getId(), user.getRole().name()));
+			AccessTokenClaim.of(user.getId(), user.getUserRole().name()));
 		String refreshToken = refreshTokenProvider.generateToken(
-			RefreshTokenClaim.of(user.getId(), user.getRole().name()));
+			RefreshTokenClaim.of(user.getId(), user.getUserRole().name()));
 
 		refreshTokenService.save(
 			RefreshToken.of(user.getId(), refreshToken, toSeconds(refreshTokenProvider.getExpiryDate(refreshToken))));

--- a/src/main/java/one/colla/auth/application/OAuthService.java
+++ b/src/main/java/one/colla/auth/application/OAuthService.java
@@ -52,7 +52,7 @@ public class OAuthService {
 		User user = User.createSocialUser(oAuthUserInfo.nickname(), oAuthUserInfo.email(), oAuthUserInfo.picture());
 		userRepository.save(user);
 		addOAuthApproval(user, oauthProvider, accessToken);
-		log.info("소셜 회원가입 - 유저 Id: {}", user.getId());
+		log.info("소셜 회원가입 - 유저 Id: {}, 공급자: {}", user.getId(), oauthProvider);
 		return user;
 	}
 
@@ -64,7 +64,7 @@ public class OAuthService {
 				approval -> updateAccessToken(approval, accessToken),
 				() -> addOAuthApproval(user, oauthProvider, accessToken));
 
-		log.info("소셜 로그인 - 유저 Id: {}", user.getId());
+		log.info("소셜 로그인 - 유저 Id: {}, 공급자: {}", user.getId(), oauthProvider);
 		return user;
 	}
 
@@ -78,6 +78,6 @@ public class OAuthService {
 		user.addOAuthApproval(oauthApproval);
 		oauthApprovalRepository.save(oauthApproval);
 
-		log.info("계정이 {}와 연동 되었습니다. - 유저 Id: {}", oauthProvider, user.getId());
+		log.info("계정 연동 - 유저 Id: {}, 공급자: {}", user.getId(), oauthProvider);
 	}
 }

--- a/src/main/java/one/colla/auth/application/OAuthService.java
+++ b/src/main/java/one/colla/auth/application/OAuthService.java
@@ -14,7 +14,7 @@ import one.colla.auth.config.OAuthProperties;
 import one.colla.auth.config.OAuthPropertyFactory;
 import one.colla.user.domain.OauthApproval;
 import one.colla.user.domain.OauthApprovalRepository;
-import one.colla.user.domain.Provider;
+import one.colla.user.domain.OauthProvider;
 import one.colla.user.domain.User;
 import one.colla.user.domain.UserRepository;
 import one.colla.user.domain.vo.Email;
@@ -32,37 +32,37 @@ public class OAuthService {
 	private final OAuthClient oAuthClient;
 	private final OauthApprovalRepository oauthApprovalRepository;
 
-	public Pair<Long, JwtPair> createToken(final OAuthLoginRequest dto, final Provider provider) {
-		OAuthProperties oAuthProperties = oAuthPropertyFactory.createOAuthProperty(provider);
+	public Pair<Long, JwtPair> createToken(final OAuthLoginRequest dto, final OauthProvider oauthProvider) {
+		OAuthProperties oAuthProperties = oAuthPropertyFactory.createOAuthProperty(oauthProvider);
 		OAuthTokenResponse tokenResponse = oAuthClient.getAccessToken(oAuthProperties, dto.code());
-		OAuthUserInfo oAuthUserInfo = oAuthUserCreator.createUser(tokenResponse, provider);
-		User user = findOrCreateUser(oAuthUserInfo, provider, tokenResponse.accessToken());
+		OAuthUserInfo oAuthUserInfo = oAuthUserCreator.createUser(tokenResponse, oauthProvider);
+		User user = findOrCreateUser(oAuthUserInfo, oauthProvider, tokenResponse.accessToken());
 		JwtPair jwtPair = jwtService.createToken(user);
 		return Pair.of(user.getId(), jwtPair);
 	}
 
-	private User findOrCreateUser(final OAuthUserInfo oAuthUserInfo, final Provider provider,
+	private User findOrCreateUser(final OAuthUserInfo oAuthUserInfo, final OauthProvider oauthProvider,
 		final String accessToken) {
 		return userRepository.findByEmail(new Email(oAuthUserInfo.email()))
-			.map(user -> updateUserWithOAuthApproval(user, provider, accessToken))
-			.orElseGet(() -> registerNewUser(oAuthUserInfo, provider, accessToken));
+			.map(user -> updateUserWithOAuthApproval(user, oauthProvider, accessToken))
+			.orElseGet(() -> registerNewUser(oAuthUserInfo, oauthProvider, accessToken));
 	}
 
-	private User registerNewUser(OAuthUserInfo oAuthUserInfo, Provider provider, String accessToken) {
+	private User registerNewUser(OAuthUserInfo oAuthUserInfo, OauthProvider oauthProvider, String accessToken) {
 		User user = User.createSocialUser(oAuthUserInfo.nickname(), oAuthUserInfo.email(), oAuthUserInfo.picture());
 		userRepository.save(user);
-		addOAuthApproval(user, provider, accessToken);
+		addOAuthApproval(user, oauthProvider, accessToken);
 		log.info("소셜 회원가입 - 유저 Id: {}", user.getId());
 		return user;
 	}
 
-	private User updateUserWithOAuthApproval(User user, Provider provider, String accessToken) {
+	private User updateUserWithOAuthApproval(User user, OauthProvider oauthProvider, String accessToken) {
 		user.getOauthApprovals().stream()
-			.filter(approval -> approval.getProvider().equals(provider))
+			.filter(approval -> approval.getOauthProvider().equals(oauthProvider))
 			.findFirst()
 			.ifPresentOrElse(
 				approval -> updateAccessToken(approval, accessToken),
-				() -> addOAuthApproval(user, provider, accessToken));
+				() -> addOAuthApproval(user, oauthProvider, accessToken));
 
 		log.info("소셜 로그인 - 유저 Id: {}", user.getId());
 		return user;
@@ -73,11 +73,11 @@ public class OAuthService {
 		// log.info("유저 {}의 {} Access token이 업데이트 되었습니다.", approval.getUser().getId(), approval.getProvider());
 	}
 
-	private void addOAuthApproval(User user, Provider provider, String accessToken) {
-		OauthApproval oauthApproval = OauthApproval.createOAuthApproval(user, provider, accessToken);
+	private void addOAuthApproval(User user, OauthProvider oauthProvider, String accessToken) {
+		OauthApproval oauthApproval = OauthApproval.createOAuthApproval(user, oauthProvider, accessToken);
 		user.addOAuthApproval(oauthApproval);
 		oauthApprovalRepository.save(oauthApproval);
 
-		log.info("계정이 {}와 연동 되었습니다. - 유저 Id: {}", provider, user.getId());
+		log.info("계정이 {}와 연동 되었습니다. - 유저 Id: {}", oauthProvider, user.getId());
 	}
 }

--- a/src/main/java/one/colla/auth/application/OAuthUserCreator.java
+++ b/src/main/java/one/colla/auth/application/OAuthUserCreator.java
@@ -16,7 +16,7 @@ import one.colla.auth.application.dto.oauth.OAuthUserInfo;
 import one.colla.common.util.TokenParser;
 import one.colla.global.exception.CommonException;
 import one.colla.global.exception.ExceptionCode;
-import one.colla.user.domain.Provider;
+import one.colla.user.domain.OauthProvider;
 import one.colla.user.domain.vo.Username;
 
 @Component
@@ -33,10 +33,10 @@ public class OAuthUserCreator {
 		this.tokenParser = tokenParser;
 	}
 
-	public OAuthUserInfo createUser(OAuthTokenResponse tokenResponse, Provider provider) {
-		return switch (provider) {
+	public OAuthUserInfo createUser(OAuthTokenResponse tokenResponse, OauthProvider oauthProvider) {
+		return switch (oauthProvider) {
 			case NAVER -> createNaverUser(tokenResponse.accessToken());
-			case GOOGLE, KAKAO -> createOtherUser(tokenResponse.idToken(), provider);
+			case GOOGLE, KAKAO -> createOtherUser(tokenResponse.idToken(), oauthProvider);
 		};
 	}
 
@@ -52,16 +52,16 @@ public class OAuthUserCreator {
 		return new OAuthUserInfo(email, adjustNameLength(username), picture);
 	}
 
-	private OAuthUserInfo createOtherUser(String idToken, Provider provider) {
+	private OAuthUserInfo createOtherUser(String idToken, OauthProvider oauthProvider) {
 		Map<String, Object> payload = tokenParser.parseIdTokenPayload(idToken);
 		String email = (String)payload.get("email");
-		String username = extractNameFromPayload(payload, provider);
+		String username = extractNameFromPayload(payload, oauthProvider);
 		String picture = (String)payload.get("picture");
 		return new OAuthUserInfo(email, adjustNameLength(username), picture);
 	}
 
-	private String extractNameFromPayload(Map<String, Object> payload, Provider provider) {
-		return switch (provider) {
+	private String extractNameFromPayload(Map<String, Object> payload, OauthProvider oauthProvider) {
+		return switch (oauthProvider) {
 			case GOOGLE -> (String)payload.get("name");
 			case KAKAO -> (String)payload.get("nickname");
 			default -> throw new CommonException(ExceptionCode.INVALID_OAUTH_PROVIDER);

--- a/src/main/java/one/colla/auth/application/dto/response/LoginResponse.java
+++ b/src/main/java/one/colla/auth/application/dto/response/LoginResponse.java
@@ -2,9 +2,10 @@ package one.colla.auth.application.dto.response;
 
 public record LoginResponse(
 	String accessToken,
-	Long userId
+	Long userId,
+	boolean hasTeam
 ) {
-	public static LoginResponse of(String accessToken, Long userId) {
-		return new LoginResponse(accessToken, userId);
+	public static LoginResponse of(String accessToken, Long userId, boolean hasTeam) {
+		return new LoginResponse(accessToken, userId, hasTeam);
 	}
 }

--- a/src/main/java/one/colla/auth/config/OAuthPropertyFactory.java
+++ b/src/main/java/one/colla/auth/config/OAuthPropertyFactory.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import one.colla.user.domain.Provider;
+import one.colla.user.domain.OauthProvider;
 
 @Slf4j
 @Component
@@ -15,8 +15,8 @@ public class OAuthPropertyFactory {
 	private final KakaoOAuthProperties kakaoOAuthProperties;
 	private final NaverOAuthProperties naverOAuthProperties;
 
-	public OAuthProperties createOAuthProperty(final Provider provider) {
-		return switch (provider) {
+	public OAuthProperties createOAuthProperty(final OauthProvider oauthProvider) {
+		return switch (oauthProvider) {
 			case GOOGLE -> googleOAuthProperties;
 			case KAKAO -> kakaoOAuthProperties;
 			case NAVER -> naverOAuthProperties;

--- a/src/main/java/one/colla/auth/presentation/AuthController.java
+++ b/src/main/java/one/colla/auth/presentation/AuthController.java
@@ -35,7 +35,7 @@ import one.colla.auth.config.OAuthPropertyFactory;
 import one.colla.common.presentation.ApiResponse;
 import one.colla.common.util.CookieUtil;
 import one.colla.common.util.oauth.OAuthUriGenerator;
-import one.colla.user.domain.Provider;
+import one.colla.user.domain.OauthProvider;
 
 @RestController
 @RequiredArgsConstructor
@@ -52,8 +52,8 @@ public class AuthController {
 
 	@GetMapping("/oauth/{provider}/login")
 	public ResponseEntity<ApiResponse<OauthLoginUrlResponse>> getOAuthUrl(
-		@PathVariable(value = "provider") final Provider provider) {
-		OAuthProperties oAuthProperties = oAuthPropertyFactory.createOAuthProperty(provider);
+		@PathVariable(value = "provider") final OauthProvider oauthProvider) {
+		OAuthProperties oAuthProperties = oAuthPropertyFactory.createOAuthProperty(oauthProvider);
 		OauthLoginUrlResponse oauthUrl = oAuthUriGenerator.generate(oAuthProperties);
 		return ResponseEntity.ok()
 			.body(ApiResponse.createSuccessResponse(oauthUrl));
@@ -61,8 +61,8 @@ public class AuthController {
 
 	@PostMapping("/oauth/{provider}/code")
 	public ResponseEntity<ApiResponse<LoginResponse>> oauthRegisterOrLogin(
-		@PathVariable("provider") final Provider provider, @RequestBody @Valid OAuthLoginRequest request) {
-		return createAuthResponse(oAuthService.createToken(request, provider));
+		@PathVariable("provider") final OauthProvider oauthProvider, @RequestBody @Valid OAuthLoginRequest request) {
+		return createAuthResponse(oAuthService.createToken(request, oauthProvider));
 	}
 
 	@PostMapping("/login")

--- a/src/main/java/one/colla/auth/presentation/AuthController.java
+++ b/src/main/java/one/colla/auth/presentation/AuthController.java
@@ -35,6 +35,7 @@ import one.colla.auth.config.OAuthPropertyFactory;
 import one.colla.common.presentation.ApiResponse;
 import one.colla.common.util.CookieUtil;
 import one.colla.common.util.oauth.OAuthUriGenerator;
+import one.colla.user.application.UserService;
 import one.colla.user.domain.OauthProvider;
 
 @RestController
@@ -49,6 +50,7 @@ public class AuthController {
 	private final OAuthPropertyFactory oAuthPropertyFactory;
 	private final OAuthUriGenerator oAuthUriGenerator;
 	private final OAuthService oAuthService;
+	private final UserService userService;
 
 	@GetMapping("/oauth/{provider}/login")
 	public ResponseEntity<ApiResponse<OauthLoginUrlResponse>> getOAuthUrl(
@@ -117,8 +119,11 @@ public class AuthController {
 
 		ResponseCookie cookie = cookieUtil.createCookie("refreshToken", refreshToken,
 			Duration.ofDays(REFRESH_TOKEN_EXPIRES_IN_DAYS).toSeconds());
+
+		boolean hasTeam = userService.hasTeam(userId);
+
 		return ResponseEntity.ok()
 			.header(HttpHeaders.SET_COOKIE, cookie.toString())
-			.body(ApiResponse.createSuccessResponse(LoginResponse.of(accessToken, userId)));
+			.body(ApiResponse.createSuccessResponse(LoginResponse.of(accessToken, userId, hasTeam)));
 	}
 }

--- a/src/main/java/one/colla/chat/domain/ChatChannelMessage.java
+++ b/src/main/java/one/colla/chat/domain/ChatChannelMessage.java
@@ -43,7 +43,7 @@ public class ChatChannelMessage {
 
 	@Column(name = "type", nullable = false)
 	@Enumerated(EnumType.STRING)
-	private Type type;
+	private ChatType chatType;
 
 	@Column(name = "content")
 	private String content;

--- a/src/main/java/one/colla/chat/domain/ChatType.java
+++ b/src/main/java/one/colla/chat/domain/ChatType.java
@@ -1,6 +1,6 @@
 package one.colla.chat.domain;
 
-public enum Type {
+public enum ChatType {
 	TEXT,
 	IMAGE,
 	FILE

--- a/src/main/java/one/colla/common/domain/vo/Url.java
+++ b/src/main/java/one/colla/common/domain/vo/Url.java
@@ -2,14 +2,9 @@ package one.colla.common.domain.vo;
 
 import java.util.regex.Pattern;
 
-import jakarta.persistence.Embeddable;
-import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import one.colla.global.exception.VoException;
 
-@Embeddable
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public abstract class Url {
 	protected static final String URL_REGEX =

--- a/src/main/java/one/colla/common/security/authentication/CustomUserDetails.java
+++ b/src/main/java/one/colla/common/security/authentication/CustomUserDetails.java
@@ -36,7 +36,7 @@ public class CustomUserDetails implements UserDetails {
 			.userId(user.getId())
 			.username(user.getUsernameValue())
 			.userEmail(user.getEmailValue())
-			.authorities(List.of(new SimpleGrantedAuthority(ROLE_PREFIX + user.getRole().name())))
+			.authorities(List.of(new SimpleGrantedAuthority(ROLE_PREFIX + user.getUserRole().name())))
 			.build();
 	}
 

--- a/src/main/java/one/colla/common/util/StringToProviderConverter.java
+++ b/src/main/java/one/colla/common/util/StringToProviderConverter.java
@@ -3,14 +3,14 @@ package one.colla.common.util;
 import org.springframework.core.convert.converter.Converter;
 
 import lombok.extern.slf4j.Slf4j;
-import one.colla.user.domain.Provider;
+import one.colla.user.domain.OauthProvider;
 
 @Slf4j
-public class StringToProviderConverter implements Converter<String, Provider> {
+public class StringToProviderConverter implements Converter<String, OauthProvider> {
 	@Override
-	public Provider convert(final String provider) {
+	public OauthProvider convert(final String provider) {
 
-		return Provider.valueOf(provider.toUpperCase());
+		return OauthProvider.valueOf(provider.toUpperCase());
 	}
 
 }

--- a/src/main/java/one/colla/feed/collect/domain/CollectFeedResponse.java
+++ b/src/main/java/one/colla/feed/collect/domain/CollectFeedResponse.java
@@ -44,7 +44,7 @@ public class CollectFeedResponse extends BaseEntity {
 
 	@Column(name = "status", nullable = false)
 	@Enumerated(EnumType.STRING)
-	private Status status;
+	private CollectFeedStatus collectFeedStatus;
 
 	public static class CollectFeedResponseId extends CompositeKeyBase {
 		@Column(name = "collect_feed_id")

--- a/src/main/java/one/colla/feed/collect/domain/CollectFeedStatus.java
+++ b/src/main/java/one/colla/feed/collect/domain/CollectFeedStatus.java
@@ -1,6 +1,6 @@
 package one.colla.feed.collect.domain;
 
-public enum Status {
+public enum CollectFeedStatus {
 	PENDING,
 	COMPLETED
 }

--- a/src/main/java/one/colla/file/domain/Attachment.java
+++ b/src/main/java/one/colla/file/domain/Attachment.java
@@ -43,7 +43,7 @@ public class Attachment extends BaseEntity {
 
 	@Column(name = "type", nullable = false)
 	@Enumerated(EnumType.STRING)
-	private Type type;
+	private AttachmentType attachmentType;
 
 	@Column(name = "size", nullable = false)
 	private Long size;

--- a/src/main/java/one/colla/file/domain/AttachmentType.java
+++ b/src/main/java/one/colla/file/domain/AttachmentType.java
@@ -1,6 +1,6 @@
 package one.colla.file.domain;
 
-public enum Type {
+public enum AttachmentType {
 	IMAGE,
 	FILE
 }

--- a/src/main/java/one/colla/infra/redis/lastseen/LastSeenTeamspace.java
+++ b/src/main/java/one/colla/infra/redis/lastseen/LastSeenTeamspace.java
@@ -1,0 +1,36 @@
+package one.colla.infra.redis.lastseen;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@RedisHash("lastSeenTeamspace")
+@Getter
+@ToString(of = {"userId", "teamspaceId"})
+@EqualsAndHashCode(of = {"userId", "teamspaceId"})
+public class LastSeenTeamspace {
+	@Id
+	private final Long userId;
+	private Long teamspaceId;
+
+	@Builder
+	private LastSeenTeamspace(Long userId, Long teamspaceId) {
+		this.userId = userId;
+		this.teamspaceId = teamspaceId;
+	}
+
+	public static LastSeenTeamspace of(Long userId, Long teamspaceId) {
+		return LastSeenTeamspace.builder()
+			.userId(userId)
+			.teamspaceId(teamspaceId)
+			.build();
+	}
+
+	protected void updateLastSeenTeamspace(Long teamspaceId) {
+		this.teamspaceId = teamspaceId;
+	}
+}

--- a/src/main/java/one/colla/infra/redis/lastseen/LastSeenTeamspaceRepository.java
+++ b/src/main/java/one/colla/infra/redis/lastseen/LastSeenTeamspaceRepository.java
@@ -1,0 +1,6 @@
+package one.colla.infra.redis.lastseen;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface LastSeenTeamspaceRepository extends CrudRepository<LastSeenTeamspace, Long> {
+}

--- a/src/main/java/one/colla/infra/redis/lastseen/LastSeenTeamspaceService.java
+++ b/src/main/java/one/colla/infra/redis/lastseen/LastSeenTeamspaceService.java
@@ -1,0 +1,26 @@
+package one.colla.infra.redis.lastseen;
+
+import java.util.Optional;
+
+public interface LastSeenTeamspaceService {
+
+	/**
+	 * 마지막으로 본 팀스페이스 id를 redis 저장한다.
+	 *
+	 * @param lastSeenTeamspace :  {@link LastSeenTeamspace}
+	 */
+	void save(LastSeenTeamspace lastSeenTeamspace);
+
+	/**
+	 *
+	 * @param userId : 조회할 userId
+	 * */
+	Optional<LastSeenTeamspace> findByUserId(Long userId);
+
+	/**
+	 *
+	 * @param teamSpaceId : 수정할 유저 Id
+	 * @param teamSpaceId : 마지막으로 본 팀스페이스 Id
+	 * */
+	void updateLastSeenTeamspace(Long userId, Long teamSpaceId);
+}

--- a/src/main/java/one/colla/infra/redis/lastseen/LastSeenTeamspaceServiceImpl.java
+++ b/src/main/java/one/colla/infra/redis/lastseen/LastSeenTeamspaceServiceImpl.java
@@ -1,0 +1,39 @@
+package one.colla.infra.redis.lastseen;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class LastSeenTeamspaceServiceImpl implements LastSeenTeamspaceService {
+	private final LastSeenTeamspaceRepository lastSeenTeamspaceRepository;
+
+	@Override
+	public void save(LastSeenTeamspace lastSeenTeamspace) {
+		lastSeenTeamspaceRepository.save(lastSeenTeamspace);
+	}
+
+	@Override
+	public Optional<LastSeenTeamspace> findByUserId(Long userId) {
+		return lastSeenTeamspaceRepository.findById(userId);
+	}
+
+	@Override
+	public void updateLastSeenTeamspace(Long userId, Long teamSpaceId) {
+		LastSeenTeamspace lastSeenTeamspace = findOrCreateLastSeenTeamspace(userId);
+		lastSeenTeamspace.updateLastSeenTeamspace(teamSpaceId);
+		save(lastSeenTeamspace);
+	}
+
+	private LastSeenTeamspace findOrCreateLastSeenTeamspace(Long userId) {
+		return lastSeenTeamspaceRepository.findById(userId)
+			.orElseGet(() -> createLastSeenTeamspace(userId));
+	}
+
+	private LastSeenTeamspace createLastSeenTeamspace(Long userId) {
+		return LastSeenTeamspace.of(userId, null);
+	}
+}

--- a/src/main/java/one/colla/schedule/domain/CalendarEventSubtodo.java
+++ b/src/main/java/one/colla/schedule/domain/CalendarEventSubtodo.java
@@ -40,6 +40,6 @@ public class CalendarEventSubtodo extends BaseEntity {
 
 	@Column(name = "status", nullable = false)
 	@Enumerated(EnumType.STRING)
-	private Status status;
+	private CalendarEventTodoStatus status;
 
 }

--- a/src/main/java/one/colla/schedule/domain/CalendarEventTodo.java
+++ b/src/main/java/one/colla/schedule/domain/CalendarEventTodo.java
@@ -19,7 +19,7 @@ public class CalendarEventTodo extends CalendarEvent {
 
 	@Column(name = "status", nullable = false)
 	@Enumerated(EnumType.STRING)
-	private Status status;
+	private CalendarEventTodoStatus status;
 
 	@OneToMany(mappedBy = "calendarEventTodo", fetch = FetchType.LAZY)
 	private final List<CalendarEventSubtodo> calendarEventSubtodos = new ArrayList<>();

--- a/src/main/java/one/colla/schedule/domain/CalendarEventTodoStatus.java
+++ b/src/main/java/one/colla/schedule/domain/CalendarEventTodoStatus.java
@@ -1,6 +1,6 @@
 package one.colla.schedule.domain;
 
-public enum Status {
+public enum CalendarEventTodoStatus {
 	REQUEST,
 	PROCESS,
 	FEEDBACK,

--- a/src/main/java/one/colla/teamspace/application/TeamspaceService.java
+++ b/src/main/java/one/colla/teamspace/application/TeamspaceService.java
@@ -37,9 +37,9 @@ import one.colla.teamspace.domain.TeamspaceRepository;
 import one.colla.teamspace.domain.TeamspaceRole;
 import one.colla.teamspace.domain.UserTeamspace;
 import one.colla.teamspace.domain.UserTeamspaceRepository;
-import one.colla.teamspace.domain.vo.ProfileImageUrl;
 import one.colla.teamspace.domain.vo.TagName;
 import one.colla.teamspace.domain.vo.TeamspaceName;
+import one.colla.teamspace.domain.vo.TeamspaceProfileImageUrl;
 import one.colla.user.domain.User;
 import one.colla.user.domain.UserRepository;
 
@@ -208,8 +208,8 @@ public class TeamspaceService {
 		}
 
 		if (request.profileImageUrl() != null) {
-			ProfileImageUrl profileImageUrl = new ProfileImageUrl(request.profileImageUrl());
-			teamspace.changeProfileImageUrl(profileImageUrl);
+			TeamspaceProfileImageUrl teamspaceProfileImageUrl = new TeamspaceProfileImageUrl(request.profileImageUrl());
+			teamspace.changeProfileImageUrl(teamspaceProfileImageUrl);
 		}
 
 		if (request.users() != null && !request.users().isEmpty()) {

--- a/src/main/java/one/colla/teamspace/domain/Teamspace.java
+++ b/src/main/java/one/colla/teamspace/domain/Teamspace.java
@@ -19,8 +19,8 @@ import one.colla.common.domain.BaseEntity;
 import one.colla.feed.common.domain.Feed;
 import one.colla.file.domain.Attachment;
 import one.colla.schedule.domain.CalendarEvent;
-import one.colla.teamspace.domain.vo.ProfileImageUrl;
 import one.colla.teamspace.domain.vo.TeamspaceName;
+import one.colla.teamspace.domain.vo.TeamspaceProfileImageUrl;
 
 @Getter
 @Entity
@@ -35,7 +35,7 @@ public class Teamspace extends BaseEntity {
 	private TeamspaceName teamspaceName;
 
 	@Embedded
-	private ProfileImageUrl profileImageUrl;
+	private TeamspaceProfileImageUrl teamspaceProfileImageUrl;
 
 	@OneToMany(mappedBy = "teamspace", fetch = FetchType.LAZY)
 	private final List<UserTeamspace> userTeamspaces = new ArrayList<>();
@@ -69,7 +69,7 @@ public class Teamspace extends BaseEntity {
 	}
 
 	public String getProfileImageUrlValue() {
-		return profileImageUrl != null ? profileImageUrl.getValue() : null;
+		return teamspaceProfileImageUrl != null ? teamspaceProfileImageUrl.getValue() : null;
 	}
 
 	public void addUserTeamspace(final UserTeamspace userTeamspace) {
@@ -84,7 +84,7 @@ public class Teamspace extends BaseEntity {
 		this.teamspaceName = teamspaceName;
 	}
 
-	public void changeProfileImageUrl(final ProfileImageUrl profileImageUrl) {
-		this.profileImageUrl = profileImageUrl;
+	public void changeProfileImageUrl(final TeamspaceProfileImageUrl teamspaceProfileImageUrl) {
+		this.teamspaceProfileImageUrl = teamspaceProfileImageUrl;
 	}
 }

--- a/src/main/java/one/colla/teamspace/domain/vo/TeamspaceProfileImageUrl.java
+++ b/src/main/java/one/colla/teamspace/domain/vo/TeamspaceProfileImageUrl.java
@@ -1,10 +1,12 @@
 package one.colla.teamspace.domain.vo;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import one.colla.common.domain.vo.Url;
 
+@Embeddable
 @EqualsAndHashCode(callSuper = false)
 @Getter
 public class TeamspaceProfileImageUrl extends Url {

--- a/src/main/java/one/colla/teamspace/domain/vo/TeamspaceProfileImageUrl.java
+++ b/src/main/java/one/colla/teamspace/domain/vo/TeamspaceProfileImageUrl.java
@@ -7,22 +7,22 @@ import one.colla.common.domain.vo.Url;
 
 @EqualsAndHashCode(callSuper = false)
 @Getter
-public class ProfileImageUrl extends Url {
+public class TeamspaceProfileImageUrl extends Url {
 
 	@Column(name = "profile_image_url")
 	private final String value;
 
-	public ProfileImageUrl() {
+	public TeamspaceProfileImageUrl() {
 		this.value = null;
 	}
 
-	public ProfileImageUrl(final String value) {
+	public TeamspaceProfileImageUrl(final String value) {
 		validate(value);
 		this.value = value;
 	}
 
-	public ProfileImageUrl change(final String newUrl) {
-		return new ProfileImageUrl(newUrl);
+	public TeamspaceProfileImageUrl change(final String newUrl) {
+		return new TeamspaceProfileImageUrl(newUrl);
 	}
 
 }

--- a/src/main/java/one/colla/user/application/UserService.java
+++ b/src/main/java/one/colla/user/application/UserService.java
@@ -55,6 +55,7 @@ public class UserService {
 		return UserStatusResponse.of(profile, participatedTeamspaces);
 	}
 
+	@Transactional
 	public void updateLastSeenTeamspace(CustomUserDetails userDetails, LastSeenUpdateRequest request) {
 		UserTeamspace userTeamspace = teamspaceService.getUserTeamspace(userDetails, request.teamspaceId());
 

--- a/src/main/java/one/colla/user/application/UserService.java
+++ b/src/main/java/one/colla/user/application/UserService.java
@@ -65,10 +65,17 @@ public class UserService {
 		);
 	}
 
+	@Transactional(readOnly = true)
+	public boolean hasTeam(Long userId) {
+		final User user = userRepository.findById(userId)
+			.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_USER));
+
+		return !user.getUserTeamspaces().isEmpty();
+	}
+
 	private int getNumOfTeamspaceParticipants(UserTeamspace userTeamspace) {
 		return userTeamspace.getTeamspace()
 			.getUserTeamspaces()
 			.size();
 	}
-
 }

--- a/src/main/java/one/colla/user/application/UserService.java
+++ b/src/main/java/one/colla/user/application/UserService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import one.colla.common.security.authentication.CustomUserDetails;
 import one.colla.global.exception.CommonException;
 import one.colla.global.exception.ExceptionCode;
@@ -23,6 +24,7 @@ import one.colla.user.domain.UserRepository;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserService {
 	private final UserRepository userRepository;
 	private final LastSeenTeamspaceService lastSeenTeamspaceService;
@@ -52,6 +54,7 @@ public class UserService {
 			)
 			.toList();
 
+		log.info("사용자 관련 정보 조회 - 사용자 Id: {}", userDetails.getUserId());
 		return UserStatusResponse.of(profile, participatedTeamspaces);
 	}
 
@@ -63,6 +66,7 @@ public class UserService {
 			userTeamspace.getUser().getId(),
 			userTeamspace.getTeamspace().getId()
 		);
+		log.info("마지막 접근 팀스페이스 업데이트 - 팀스페이스 Id: {}, 사용자 Id: {}", request.teamspaceId(), userDetails.getUserId());
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/one/colla/user/application/UserService.java
+++ b/src/main/java/one/colla/user/application/UserService.java
@@ -1,11 +1,23 @@
 package one.colla.user.application;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.global.exception.CommonException;
+import one.colla.global.exception.ExceptionCode;
+import one.colla.infra.redis.lastseen.LastSeenTeamspace;
+import one.colla.infra.redis.lastseen.LastSeenTeamspaceService;
+import one.colla.teamspace.application.TeamspaceService;
+import one.colla.teamspace.domain.UserTeamspace;
+import one.colla.user.application.dto.request.LastSeenUpdateRequest;
+import one.colla.user.application.dto.response.ParticipatedTeamspaceDto;
+import one.colla.user.application.dto.response.ProfileDto;
+import one.colla.user.application.dto.response.UserStatusResponse;
 import one.colla.user.domain.User;
 import one.colla.user.domain.UserRepository;
 
@@ -13,9 +25,49 @@ import one.colla.user.domain.UserRepository;
 @RequiredArgsConstructor
 public class UserService {
 	private final UserRepository userRepository;
+	private final LastSeenTeamspaceService lastSeenTeamspaceService;
+	private final TeamspaceService teamspaceService;
 
 	@Transactional(readOnly = true)
 	public Optional<User> getUserById(Long id) {
 		return userRepository.findById(id);
 	}
+
+	@Transactional(readOnly = true)
+	public UserStatusResponse getUserStatus(CustomUserDetails userDetails) {
+		final User user = userRepository.findById(userDetails.getUserId())
+			.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_USER));
+
+		Long lastSeenTeamspaceId = lastSeenTeamspaceService.findByUserId(user.getId())
+			.map(LastSeenTeamspace::getTeamspaceId)
+			.orElse(null);
+
+		ProfileDto profile = ProfileDto.of(user.getId(), user, lastSeenTeamspaceId);
+
+		List<ParticipatedTeamspaceDto> participatedTeamspaces = user.getUserTeamspaces().stream()
+			.map(ut -> ParticipatedTeamspaceDto.of(
+				ut.getTeamspace().getId(),
+				ut,
+				getNumOfTeamspaceParticipants(ut))
+			)
+			.toList();
+
+		return UserStatusResponse.of(profile, participatedTeamspaces);
+	}
+
+	public void updateLastSeenTeamspace(CustomUserDetails userDetails, LastSeenUpdateRequest request) {
+		UserTeamspace userTeamspace = teamspaceService.getUserTeamspace(userDetails, request.teamspaceId());
+
+		lastSeenTeamspaceService.updateLastSeenTeamspace(
+			userTeamspace.getUser().getId(),
+			userTeamspace.getTeamspace().getId()
+		);
+	}
+
+	private int getNumOfTeamspaceParticipants(UserTeamspace userTeamspace) {
+		return userTeamspace.getTeamspace()
+			.getUserTeamspaces()
+			.size();
+	}
+
 }

--- a/src/main/java/one/colla/user/application/dto/request/LastSeenUpdateRequest.java
+++ b/src/main/java/one/colla/user/application/dto/request/LastSeenUpdateRequest.java
@@ -1,0 +1,9 @@
+package one.colla.user.application.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record LastSeenUpdateRequest(
+	@NotNull
+	Long teamspaceId
+) {
+}

--- a/src/main/java/one/colla/user/application/dto/response/ParticipatedTeamspaceDto.java
+++ b/src/main/java/one/colla/user/application/dto/response/ParticipatedTeamspaceDto.java
@@ -1,0 +1,28 @@
+package one.colla.user.application.dto.response;
+
+import lombok.Builder;
+import one.colla.teamspace.domain.TeamspaceRole;
+import one.colla.teamspace.domain.UserTeamspace;
+
+@Builder
+public record ParticipatedTeamspaceDto(
+	Long teamspaceId,
+	String name,
+	String profileImageUrl,
+	TeamspaceRole teamspaceRole,
+	int numOfParticipants
+) {
+	public static ParticipatedTeamspaceDto of(
+		Long teamspaceId,
+		UserTeamspace userTeamspace,
+		int numOfTeamspaceParticipants) {
+		return ParticipatedTeamspaceDto.builder()
+			.teamspaceId(teamspaceId)
+			.name(userTeamspace.getTeamspace().getTeamspaceNameValue())
+			.profileImageUrl(userTeamspace.getTeamspace().getProfileImageUrlValue())
+			.teamspaceRole(userTeamspace.getTeamspaceRole())
+			.numOfParticipants(numOfTeamspaceParticipants)
+			.build();
+
+	}
+}

--- a/src/main/java/one/colla/user/application/dto/response/ProfileDto.java
+++ b/src/main/java/one/colla/user/application/dto/response/ProfileDto.java
@@ -1,0 +1,29 @@
+package one.colla.user.application.dto.response;
+
+import lombok.Builder;
+import one.colla.user.domain.CommentNotification;
+import one.colla.user.domain.User;
+
+@Builder
+public record ProfileDto(
+	Long userId,
+	String username,
+	String profileImageUrl,
+	String email,
+	boolean emailSubscription,
+	CommentNotification commentNotification,
+	Long lastSeenTeamspaceId
+) {
+
+	public static ProfileDto of(Long userID, User user, Long lastSeenTeamspaceId) {
+		return ProfileDto.builder()
+			.userId(userID)
+			.username(user.getUsernameValue())
+			.profileImageUrl(user.getProfileImageUrlValue())
+			.email(user.getEmailValue())
+			.emailSubscription(user.isEmailSubscription())
+			.commentNotification(user.getCommentNotification())
+			.lastSeenTeamspaceId(lastSeenTeamspaceId)
+			.build();
+	}
+}

--- a/src/main/java/one/colla/user/application/dto/response/UserStatusResponse.java
+++ b/src/main/java/one/colla/user/application/dto/response/UserStatusResponse.java
@@ -1,0 +1,15 @@
+package one.colla.user.application.dto.response;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record UserStatusResponse(
+	ProfileDto profile,
+	List<ParticipatedTeamspaceDto> participatedTeamspaces
+) {
+	public static UserStatusResponse of(ProfileDto profile, List<ParticipatedTeamspaceDto> participatedTeamspaces) {
+		return new UserStatusResponse(profile, participatedTeamspaces);
+	}
+}

--- a/src/main/java/one/colla/user/domain/OauthApproval.java
+++ b/src/main/java/one/colla/user/domain/OauthApproval.java
@@ -32,23 +32,23 @@ public class OauthApproval extends BaseEntity {
 
 	@Column(name = "provider", nullable = false)
 	@Enumerated(EnumType.STRING)
-	private Provider provider;
+	private OauthProvider oauthProvider;
 
 	@Column(name = "access_token", nullable = false)
 	private String accessToken;
 
-	private OauthApproval(final User user, final Provider provider, final String accessToken) {
+	private OauthApproval(final User user, final OauthProvider oauthProvider, final String accessToken) {
 		this.user = user;
-		this.provider = provider;
+		this.oauthProvider = oauthProvider;
 		this.accessToken = accessToken;
 	}
 
 	public static OauthApproval createOAuthApproval(
 		final User user,
-		final Provider provider,
+		final OauthProvider oauthProvider,
 		final String accessToken) {
 
-		return new OauthApproval(user, provider, accessToken);
+		return new OauthApproval(user, oauthProvider, accessToken);
 	}
 
 	public void changeAccessToken(final String accessToken) {

--- a/src/main/java/one/colla/user/domain/OauthProvider.java
+++ b/src/main/java/one/colla/user/domain/OauthProvider.java
@@ -1,6 +1,6 @@
 package one.colla.user.domain;
 
-public enum Provider {
+public enum OauthProvider {
 	GOOGLE,
 	KAKAO,
 	NAVER

--- a/src/main/java/one/colla/user/domain/User.java
+++ b/src/main/java/one/colla/user/domain/User.java
@@ -48,7 +48,7 @@ public class User extends BaseEntity {
 
 	@Column(name = "role", nullable = false)
 	@Enumerated(EnumType.STRING)
-	private Role role;
+	private UserRole userRole;
 
 	@Embedded
 	private Username username;
@@ -70,7 +70,7 @@ public class User extends BaseEntity {
 	private CommentNotification commentNotification;
 
 	private User(Username username, String password, Email email, ProfileImageUrl profileImageUrl) {
-		this.role = Role.USER;
+		this.userRole = UserRole.USER;
 		this.username = username;
 		this.password = password;
 		this.email = email;

--- a/src/main/java/one/colla/user/domain/User.java
+++ b/src/main/java/one/colla/user/domain/User.java
@@ -146,6 +146,10 @@ public class User extends BaseEntity {
 		return profileImageUrl != null ? profileImageUrl.getValue() : null;
 	}
 
+	public void updateProfileImage(ProfileImageUrl newProfileImageUrl) {
+		this.profileImageUrl = newProfileImageUrl;
+	}
+
 	public UserTeamspace participate(
 		final Teamspace teamspace,
 		final TeamspaceRole teamspaceRole

--- a/src/main/java/one/colla/user/domain/User.java
+++ b/src/main/java/one/colla/user/domain/User.java
@@ -33,7 +33,7 @@ import one.colla.teamspace.domain.Teamspace;
 import one.colla.teamspace.domain.TeamspaceRole;
 import one.colla.teamspace.domain.UserTeamspace;
 import one.colla.user.domain.vo.Email;
-import one.colla.user.domain.vo.ProfileImageUrl;
+import one.colla.user.domain.vo.UserProfileImageUrl;
 import one.colla.user.domain.vo.Username;
 
 @Getter
@@ -63,19 +63,19 @@ public class User extends BaseEntity {
 	private boolean emailSubscription = true;
 
 	@Embedded
-	private ProfileImageUrl profileImageUrl;
+	private UserProfileImageUrl userProfileImageUrl;
 
 	@Column(name = "comment_notification", nullable = false)
 	@Enumerated(EnumType.STRING)
 	private CommentNotification commentNotification;
 
-	private User(Username username, String password, Email email, ProfileImageUrl profileImageUrl) {
+	private User(Username username, String password, Email email, UserProfileImageUrl userProfileImageUrl) {
 		this.userRole = UserRole.USER;
 		this.username = username;
 		this.password = password;
 		this.email = email;
 		this.commentNotification = CommentNotification.ALL;
-		this.profileImageUrl = profileImageUrl;
+		this.userProfileImageUrl = userProfileImageUrl;
 	}
 
 	public static User createGeneralUser(String createUsername, String createPassword, String createEmail) {
@@ -87,8 +87,8 @@ public class User extends BaseEntity {
 	public static User createSocialUser(String createUsername, String createEmail, String createProfileImageUrl) {
 		Username username = Username.from(createUsername);
 		Email email = Email.from(createEmail);
-		ProfileImageUrl profileImageUrl = ProfileImageUrl.from(createProfileImageUrl);
-		return new User(username, null, email, profileImageUrl);
+		UserProfileImageUrl userProfileImageUrl = UserProfileImageUrl.from(createProfileImageUrl);
+		return new User(username, null, email, userProfileImageUrl);
 	}
 
 	public void addOAuthApproval(final OauthApproval oauthApproval) {
@@ -143,11 +143,11 @@ public class User extends BaseEntity {
 	}
 
 	public String getProfileImageUrlValue() {
-		return profileImageUrl != null ? profileImageUrl.getValue() : null;
+		return userProfileImageUrl != null ? userProfileImageUrl.getValue() : null;
 	}
 
-	public void updateProfileImage(ProfileImageUrl newProfileImageUrl) {
-		this.profileImageUrl = newProfileImageUrl;
+	public void updateProfileImage(UserProfileImageUrl newUserProfileImageUrl) {
+		this.userProfileImageUrl = newUserProfileImageUrl;
 	}
 
 	public UserTeamspace participate(

--- a/src/main/java/one/colla/user/domain/UserRole.java
+++ b/src/main/java/one/colla/user/domain/UserRole.java
@@ -1,6 +1,6 @@
 package one.colla.user.domain;
 
-public enum Role {
+public enum UserRole {
 	ADMIN,
 	USER
 }

--- a/src/main/java/one/colla/user/domain/vo/UserProfileImageUrl.java
+++ b/src/main/java/one/colla/user/domain/vo/UserProfileImageUrl.java
@@ -1,16 +1,22 @@
 package one.colla.user.domain.vo;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import one.colla.common.domain.vo.Url;
 
+@Embeddable
 @EqualsAndHashCode(callSuper = false)
 @Getter
 public class UserProfileImageUrl extends Url {
 
 	@Column(name = "profile_image_url")
 	private String value;
+
+	public UserProfileImageUrl() {
+		this.value = null;
+	}
 
 	public UserProfileImageUrl(final String value) {
 		validate(value);

--- a/src/main/java/one/colla/user/domain/vo/UserProfileImageUrl.java
+++ b/src/main/java/one/colla/user/domain/vo/UserProfileImageUrl.java
@@ -7,22 +7,22 @@ import one.colla.common.domain.vo.Url;
 
 @EqualsAndHashCode(callSuper = false)
 @Getter
-public class ProfileImageUrl extends Url {
+public class UserProfileImageUrl extends Url {
 
 	@Column(name = "profile_image_url")
 	private String value;
 
-	public ProfileImageUrl(final String value) {
+	public UserProfileImageUrl(final String value) {
 		validate(value);
 		this.value = value;
 	}
 
-	public static ProfileImageUrl from(final String url) {
-		return new ProfileImageUrl(url);
+	public static UserProfileImageUrl from(final String url) {
+		return new UserProfileImageUrl(url);
 	}
 
-	public ProfileImageUrl change(final String newUrl) {
-		return new ProfileImageUrl(newUrl);
+	public UserProfileImageUrl change(final String newUrl) {
+		return new UserProfileImageUrl(newUrl);
 	}
 
 }

--- a/src/main/java/one/colla/user/presentation/UserController.java
+++ b/src/main/java/one/colla/user/presentation/UserController.java
@@ -1,0 +1,47 @@
+package one.colla.user.presentation;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import one.colla.common.presentation.ApiResponse;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.user.application.UserService;
+import one.colla.user.application.dto.request.LastSeenUpdateRequest;
+import one.colla.user.application.dto.response.UserStatusResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+	private final UserService userService;
+
+	@GetMapping("/status")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<UserStatusResponse>> getUserStatus(
+		@AuthenticationPrincipal CustomUserDetails userDetails) {
+		return ResponseEntity.ok().body(
+			ApiResponse.createSuccessResponse(userService.getUserStatus(userDetails))
+		);
+	}
+
+	@PostMapping("/last-seen")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<?>> updateLastSeenTeamspace(
+		@AuthenticationPrincipal CustomUserDetails userDetails,
+		@RequestBody @Valid final LastSeenUpdateRequest request) {
+		userService.updateLastSeenTeamspace(userDetails, request);
+		return ResponseEntity.ok().body(ApiResponse.createSuccessResponse(Map.of())
+		);
+	}
+
+}

--- a/src/test/java/one/colla/auth/application/OAuthUserCreatorTest.java
+++ b/src/test/java/one/colla/auth/application/OAuthUserCreatorTest.java
@@ -28,7 +28,7 @@ import one.colla.common.CommonTest;
 import one.colla.common.util.TokenParser;
 import one.colla.global.exception.CommonException;
 import one.colla.global.exception.ExceptionCode;
-import one.colla.user.domain.Provider;
+import one.colla.user.domain.OauthProvider;
 
 public class OAuthUserCreatorTest extends CommonTest {
 
@@ -85,7 +85,7 @@ public class OAuthUserCreatorTest extends CommonTest {
 			eq(JsonNode.class)))
 			.willReturn(ResponseEntity.ok(responseNode));
 
-		OAuthUserInfo oAuthUserInfo = oAuthUserCreator.createUser(tokenResponse, Provider.NAVER);
+		OAuthUserInfo oAuthUserInfo = oAuthUserCreator.createUser(tokenResponse, OauthProvider.NAVER);
 
 		assertSoftly(softly -> {
 			softly.assertThat(oAuthUserInfo.email()).isEqualTo(EMAIL);
@@ -102,7 +102,7 @@ public class OAuthUserCreatorTest extends CommonTest {
 		OAuthTokenResponse tokenResponse = new OAuthTokenResponse(null, null, null);
 
 		// when & then
-		assertThatThrownBy(() -> oAuthUserCreator.createUser(tokenResponse, Provider.NAVER))
+		assertThatThrownBy(() -> oAuthUserCreator.createUser(tokenResponse, OauthProvider.NAVER))
 			.isInstanceOf(CommonException.class)
 			.hasMessageContaining(ExceptionCode.INVALID_AUTHORIZATION_CODE.getMessage());
 	}
@@ -129,8 +129,8 @@ public class OAuthUserCreatorTest extends CommonTest {
 		OAuthTokenResponse kakaoTokenResponse = new OAuthTokenResponse(ACCESS_TOKEN, REFRESH_TOKEN, KAKAO_ID_TOKEN);
 
 		// when
-		OAuthUserInfo googleUser = oAuthUserCreator.createUser(googleTokenResponse, Provider.GOOGLE);
-		OAuthUserInfo kakaoUser = oAuthUserCreator.createUser(kakaoTokenResponse, Provider.KAKAO);
+		OAuthUserInfo googleUser = oAuthUserCreator.createUser(googleTokenResponse, OauthProvider.GOOGLE);
+		OAuthUserInfo kakaoUser = oAuthUserCreator.createUser(kakaoTokenResponse, OauthProvider.KAKAO);
 
 		// then
 		assertSoftly(softly -> {

--- a/src/test/java/one/colla/auth/application/config/OAuthPropertiesFactoryTest.java
+++ b/src/test/java/one/colla/auth/application/config/OAuthPropertiesFactoryTest.java
@@ -17,7 +17,7 @@ import one.colla.auth.config.NaverOAuthProperties;
 import one.colla.auth.config.OAuthProperties;
 import one.colla.auth.config.OAuthPropertyFactory;
 import one.colla.common.CommonTest;
-import one.colla.user.domain.Provider;
+import one.colla.user.domain.OauthProvider;
 
 class OAuthPropertiesFactoryTest extends CommonTest {
 
@@ -27,19 +27,19 @@ class OAuthPropertiesFactoryTest extends CommonTest {
 	private static Stream<Arguments> provideOAuthPropertiesFromProvider() {
 
 		return Stream.of(
-			Arguments.of(Provider.GOOGLE, mock(GoogleOAuthProperties.class)),
-			Arguments.of(Provider.KAKAO, mock(KakaoOAuthProperties.class)),
-			Arguments.of(Provider.NAVER, mock(NaverOAuthProperties.class))
+			Arguments.of(OauthProvider.GOOGLE, mock(GoogleOAuthProperties.class)),
+			Arguments.of(OauthProvider.KAKAO, mock(KakaoOAuthProperties.class)),
+			Arguments.of(OauthProvider.NAVER, mock(NaverOAuthProperties.class))
 		);
 	}
 
 	@MethodSource("provideOAuthPropertiesFromProvider")
 	@DisplayName("Provider에 해당하는 OAuthProperties를 응답 받을 수 있다.")
 	@ParameterizedTest
-	void createOAuthProperties(Provider provider, OAuthProperties oAuthProperties) {
+	void createOAuthProperties(OauthProvider oauthProvider, OAuthProperties oAuthProperties) {
 
 		// when
-		OAuthProperties authProperties = oAuthPropertyFactory.createOAuthProperty(provider);
+		OAuthProperties authProperties = oAuthPropertyFactory.createOAuthProperty(oauthProvider);
 
 		// then
 		assertThat(authProperties).isInstanceOf(oAuthProperties.getClass());

--- a/src/test/java/one/colla/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/one/colla/auth/presentation/AuthControllerTest.java
@@ -44,7 +44,7 @@ import one.colla.common.util.CookieUtil;
 import one.colla.common.util.oauth.OAuthUriGenerator;
 import one.colla.global.exception.CommonException;
 import one.colla.global.exception.ExceptionCode;
-import one.colla.user.domain.Provider;
+import one.colla.user.domain.OauthProvider;
 
 @WebMvcTest(AuthController.class)
 class AuthControllerTest extends ControllerTest {
@@ -81,7 +81,7 @@ class AuthControllerTest extends ControllerTest {
 	class OAuthDocs {
 
 		final String URL = "example.com";
-		final Provider provider = Provider.GOOGLE;
+		final OauthProvider oauthProvider = OauthProvider.GOOGLE;
 		final OAuthProperties oAuthProperties = new GoogleOAuthProperties();
 		final OauthLoginUrlResponse oauthLoginUrlResponse = new OauthLoginUrlResponse(URL);
 
@@ -90,12 +90,12 @@ class AuthControllerTest extends ControllerTest {
 		@WithMockAnonymous
 		void getOAuthUrl() throws Exception {
 
-			given(oAuthPropertyFactory.createOAuthProperty(provider))
+			given(oAuthPropertyFactory.createOAuthProperty(oauthProvider))
 				.willReturn(oAuthProperties);
 			given(oAuthUriGenerator.generate(oAuthProperties))
 				.willReturn(oauthLoginUrlResponse);
 
-			mockMvc.perform(get("/api/v1/auth/oauth/{provider}/login", provider).with(csrf()))
+			mockMvc.perform(get("/api/v1/auth/oauth/{provider}/login", oauthProvider).with(csrf()))
 				.andExpect(status().isOk())
 				.andExpect(content().json(objectMapper.writeValueAsString(
 					ApiResponse.createSuccessResponse(oauthLoginUrlResponse))))
@@ -127,7 +127,7 @@ class AuthControllerTest extends ControllerTest {
 			final String CODE = "authCode";
 			final OAuthLoginRequest oAuthLoginRequest = new OAuthLoginRequest(CODE);
 
-			given(oAuthService.createToken(oAuthLoginRequest, provider))
+			given(oAuthService.createToken(oAuthLoginRequest, oauthProvider))
 				.willReturn(pair);
 
 			given(cookieUtil.createCookie(REFRESH_TOKEN, tokens.refreshToken(),
@@ -136,7 +136,7 @@ class AuthControllerTest extends ControllerTest {
 
 			given(cookie.toString()).willReturn(COOKIE_STRING);
 
-			mockMvc.perform(post("/api/v1/auth/oauth/{provider}/code", provider).with(csrf())
+			mockMvc.perform(post("/api/v1/auth/oauth/{provider}/code", oauthProvider).with(csrf())
 					.content(objectMapper.writeValueAsString(oAuthLoginRequest))
 					.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())

--- a/src/test/java/one/colla/auth/presentation/AuthControllerTest.java
+++ b/src/test/java/one/colla/auth/presentation/AuthControllerTest.java
@@ -44,12 +44,16 @@ import one.colla.common.util.CookieUtil;
 import one.colla.common.util.oauth.OAuthUriGenerator;
 import one.colla.global.exception.CommonException;
 import one.colla.global.exception.ExceptionCode;
+import one.colla.user.application.UserService;
 import one.colla.user.domain.OauthProvider;
 
 @WebMvcTest(AuthController.class)
 class AuthControllerTest extends ControllerTest {
 
 	final ApiResponse<Object> SUCCESS_RESPONSE = ApiResponse.createSuccessResponse(Map.of());
+
+	@MockBean
+	UserService userService;
 
 	@MockBean
 	CookieUtil cookieUtil;
@@ -126,7 +130,9 @@ class AuthControllerTest extends ControllerTest {
 
 			final String CODE = "authCode";
 			final OAuthLoginRequest oAuthLoginRequest = new OAuthLoginRequest(CODE);
+			final boolean hasTeam = true;
 
+			given(userService.hasTeam(any())).willReturn(hasTeam);
 			given(oAuthService.createToken(oAuthLoginRequest, oauthProvider))
 				.willReturn(pair);
 
@@ -141,7 +147,7 @@ class AuthControllerTest extends ControllerTest {
 					.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andExpect(content().json(objectMapper.writeValueAsString(
-					ApiResponse.createSuccessResponse(LoginResponse.of(tokens.accessToken(), USER_ID))))
+					ApiResponse.createSuccessResponse(LoginResponse.of(tokens.accessToken(), USER_ID, hasTeam))))
 				)
 				.andDo(restDocs.document(
 					resource(ResourceSnippetParameters.builder()
@@ -155,6 +161,7 @@ class AuthControllerTest extends ControllerTest {
 							fieldWithPath("content").description("응답 내용").type(JsonFieldType.OBJECT),
 							fieldWithPath("content.accessToken").description("Access token").type(JsonFieldType.STRING),
 							fieldWithPath("content.userId").description("User ID").type(JsonFieldType.NUMBER),
+							fieldWithPath("content.hasTeam").description("팀 참여 여부").type(JsonFieldType.BOOLEAN),
 							fieldWithPath("message").description("응답 메시지").type(JsonFieldType.NULL)
 						)
 						.requestSchema(Schema.schema("OAuthLoginRequest"))
@@ -292,7 +299,9 @@ class AuthControllerTest extends ControllerTest {
 
 			final String PASSWORD = "testPassword123";
 			final LoginRequest loginRequest = new LoginRequest(EMAIL, PASSWORD);
+			final boolean hasTeam = true;
 
+			given(userService.hasTeam(any())).willReturn(hasTeam);
 			given(authService.login(loginRequest)).willReturn(pair);
 			given(cookieUtil.createCookie("refreshToken", tokens.refreshToken(),
 				Duration.ofDays(REFRESH_TOKEN_EXPIRES_IN_DAYS).toSeconds())).willReturn(cookie);
@@ -303,7 +312,7 @@ class AuthControllerTest extends ControllerTest {
 					.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andExpect(content().json(objectMapper.writeValueAsString(
-					ApiResponse.createSuccessResponse(LoginResponse.of(tokens.accessToken(), USER_ID)))))
+					ApiResponse.createSuccessResponse(LoginResponse.of(tokens.accessToken(), USER_ID, hasTeam)))))
 				.andDo(restDocs.document(
 					resource(ResourceSnippetParameters.builder()
 						.tag("auth-controller")
@@ -318,6 +327,7 @@ class AuthControllerTest extends ControllerTest {
 							fieldWithPath("content.accessToken").description("성공적인 인증 후 제공되는 액세스 토큰")
 								.type(JsonFieldType.STRING),
 							fieldWithPath("content.userId").description("인증된 사용자의 ID").type(JsonFieldType.NUMBER),
+							fieldWithPath("content.hasTeam").description("팀 참여 여부").type(JsonFieldType.BOOLEAN),
 							fieldWithPath("message").description("응답 메시지").type(JsonFieldType.NULL)
 						)
 						.requestSchema(Schema.schema("LoginRequest"))

--- a/src/test/java/one/colla/common/fixtures/UserFixtures.java
+++ b/src/test/java/one/colla/common/fixtures/UserFixtures.java
@@ -6,8 +6,8 @@ import java.util.UUID;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 import one.colla.common.security.authentication.CustomUserDetails;
-import one.colla.user.domain.Role;
 import one.colla.user.domain.User;
+import one.colla.user.domain.UserRole;
 
 public class UserFixtures {
 
@@ -52,7 +52,7 @@ public class UserFixtures {
 			.userId(user.getId())
 			.username(user.getUsernameValue())
 			.userEmail(user.getEmailValue())
-			.authorities(List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())))
+			.authorities(List.of(new SimpleGrantedAuthority("ROLE_" + user.getUserRole().name())))
 			.build();
 	}
 
@@ -61,7 +61,7 @@ public class UserFixtures {
 			.userId(userId)
 			.username(USER1_USERNAME)
 			.userEmail(USER1_EMAIL)
-			.authorities(List.of(new SimpleGrantedAuthority("ROLE_" + Role.USER.name())))
+			.authorities(List.of(new SimpleGrantedAuthority("ROLE_" + UserRole.USER.name())))
 			.build();
 	}
 }

--- a/src/test/java/one/colla/teamspace/domain/vo/TeamspaceProfileImageUrlTest.java
+++ b/src/test/java/one/colla/teamspace/domain/vo/TeamspaceProfileImageUrlTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import one.colla.global.exception.VoException;
 
-class ProfileImageUrlTest {
+class TeamspaceProfileImageUrlTest {
 	@Test
 	@DisplayName("두 객체의 값이 같으면 같은 객체이다.")
 	void testEqualsAndHashCode1() {
@@ -15,8 +15,8 @@ class ProfileImageUrlTest {
 		String input = "https://example.com/profile.jpg";
 
 		// when
-		ProfileImageUrl url1 = new ProfileImageUrl(input);
-		ProfileImageUrl url2 = new ProfileImageUrl(input);
+		TeamspaceProfileImageUrl url1 = new TeamspaceProfileImageUrl(input);
+		TeamspaceProfileImageUrl url2 = new TeamspaceProfileImageUrl(input);
 
 		// then
 		assertThat(url1).isEqualTo(url2);
@@ -30,8 +30,8 @@ class ProfileImageUrlTest {
 		String input2 = "https://example.com/another.jpg";
 
 		// when
-		ProfileImageUrl url1 = new ProfileImageUrl(input1);
-		ProfileImageUrl url2 = new ProfileImageUrl(input2);
+		TeamspaceProfileImageUrl url1 = new TeamspaceProfileImageUrl(input1);
+		TeamspaceProfileImageUrl url2 = new TeamspaceProfileImageUrl(input2);
 
 		// then
 		assertThat(url1).isNotEqualTo(url2);
@@ -44,7 +44,7 @@ class ProfileImageUrlTest {
 		String validUrl = "https://example.com/profile.jpg";
 
 		// when
-		ProfileImageUrl imageUrl = new ProfileImageUrl(validUrl);
+		TeamspaceProfileImageUrl imageUrl = new TeamspaceProfileImageUrl(validUrl);
 
 		// then
 		assertThat(imageUrl.getValue()).isEqualTo(validUrl);
@@ -57,7 +57,7 @@ class ProfileImageUrlTest {
 		String invalidUrl = "htp:/example.com";
 
 		// when/then
-		assertThatThrownBy(() -> new ProfileImageUrl(invalidUrl))
+		assertThatThrownBy(() -> new TeamspaceProfileImageUrl(invalidUrl))
 			.isInstanceOf(VoException.class)
 			.hasMessageContaining("url 형식이 아닙니다.");
 	}
@@ -69,7 +69,7 @@ class ProfileImageUrlTest {
 		String blankUrl = "   ";
 
 		// when/then
-		assertThatThrownBy(() -> new ProfileImageUrl(blankUrl))
+		assertThatThrownBy(() -> new TeamspaceProfileImageUrl(blankUrl))
 			.isInstanceOf(VoException.class)
 			.hasMessageContaining("url은 공백일 수 없습니다.");
 	}
@@ -80,10 +80,10 @@ class ProfileImageUrlTest {
 		// given
 		String initialUrl = "https://example.com/old_profile.jpg";
 		String newUrl = "https://example.com/new_profile.jpg";
-		ProfileImageUrl imageUrl = new ProfileImageUrl(initialUrl);
+		TeamspaceProfileImageUrl imageUrl = new TeamspaceProfileImageUrl(initialUrl);
 
 		// when
-		ProfileImageUrl updatedImageUrl = imageUrl.change(newUrl);
+		TeamspaceProfileImageUrl updatedImageUrl = imageUrl.change(newUrl);
 
 		// then
 		assertThat(updatedImageUrl.getValue()).isNotEqualTo(initialUrl);

--- a/src/test/java/one/colla/user/application/UserServiceTest.java
+++ b/src/test/java/one/colla/user/application/UserServiceTest.java
@@ -1,0 +1,157 @@
+package one.colla.user.application;
+
+import static one.colla.common.fixtures.TeamspaceFixtures.*;
+import static one.colla.common.fixtures.UserFixtures.*;
+import static one.colla.common.fixtures.UserTeamspaceFixtures.*;
+import static one.colla.global.exception.ExceptionCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.SoftAssertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import one.colla.common.ServiceTest;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.global.exception.CommonException;
+import one.colla.global.exception.ExceptionCode;
+import one.colla.infra.redis.lastseen.LastSeenTeamspace;
+import one.colla.infra.redis.lastseen.LastSeenTeamspaceService;
+import one.colla.teamspace.application.TeamspaceService;
+import one.colla.teamspace.domain.Teamspace;
+import one.colla.teamspace.domain.UserTeamspace;
+import one.colla.teamspace.domain.vo.ProfileImageUrl;
+import one.colla.user.application.dto.request.LastSeenUpdateRequest;
+import one.colla.user.application.dto.response.UserStatusResponse;
+import one.colla.user.domain.User;
+
+public class UserServiceTest extends ServiceTest {
+
+	final String USER_PROFILE_IMAGE_URL = "http://user-profile-image.com";
+	final String OS_TEAMSPACE_PROFILE_IMAGE_URL = "http://os-profile-image.com";
+	final String DB_TEAMSPACE_PROFILE_IMAGE_URL = "http://db-profile-image.com";
+
+	@MockBean
+	private LastSeenTeamspaceService lastSeenTeamspaceService;
+
+	@MockBean
+	private TeamspaceService teamspaceService;
+
+	@Autowired
+	private UserService userService;
+
+	CustomUserDetails userDetails;
+	User user;
+	Teamspace osTeamspace;
+	Teamspace dbTeamspace;
+	UserTeamspace osUserTeamspace;
+	UserTeamspace dbUserTeamspace;
+
+	@BeforeEach
+	void setUp() {
+		user = testFixtureBuilder.buildUser(USER1());
+		user.updateProfileImage(new one.colla.user.domain.vo.ProfileImageUrl(USER_PROFILE_IMAGE_URL));
+		userDetails = createCustomUserDetailsByUser(user);
+		osTeamspace = testFixtureBuilder.buildTeamspace(OS_TEAMSPACE());
+		dbTeamspace = testFixtureBuilder.buildTeamspace(DATABASE_TEAMSPACE());
+		osTeamspace.changeProfileImageUrl(new ProfileImageUrl(OS_TEAMSPACE_PROFILE_IMAGE_URL));
+		dbTeamspace.changeProfileImageUrl(new ProfileImageUrl(DB_TEAMSPACE_PROFILE_IMAGE_URL));
+		osUserTeamspace = testFixtureBuilder.buildUserTeamspace(MEMBER_USERTEAMSPACE(user, osTeamspace));
+		dbUserTeamspace = testFixtureBuilder.buildUserTeamspace(MEMBER_USERTEAMSPACE(user, dbTeamspace));
+	}
+
+	@Nested
+	@DisplayName("사용자 프로필 및 팀스페이스 참여 세부 사항 조회시")
+	class GetUserStatusClass {
+
+		@Test
+		@DisplayName("유저가 존재한다면 조회에 성공한다.")
+		void getUserStatus_whenUserExists_returnsUserStatus() {
+			// given
+			LastSeenTeamspace lastSeenTeamspace = LastSeenTeamspace.of(user.getId(), osTeamspace.getId());
+			given(lastSeenTeamspaceService.findByUserId(user.getId())).willReturn(Optional.of(lastSeenTeamspace));
+
+			// when
+			UserStatusResponse userStatusResponse = userService.getUserStatus(userDetails);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(userStatusResponse.profile().userId()).isEqualTo(user.getId());
+				softly.assertThat(userStatusResponse.profile().email()).isEqualTo(user.getEmailValue());
+				softly.assertThat(userStatusResponse.profile().profileImageUrl())
+					.isEqualTo(user.getProfileImageUrlValue());
+				softly.assertThat(userStatusResponse.profile().emailSubscription())
+					.isEqualTo(user.isEmailSubscription());
+				softly.assertThat(userStatusResponse.profile().commentNotification())
+					.isEqualTo(user.getCommentNotification());
+				softly.assertThat(userStatusResponse.profile().lastSeenTeamspaceId())
+					.isEqualTo(lastSeenTeamspace.getTeamspaceId());
+				softly.assertThat(userStatusResponse.participatedTeamspaces()).hasSize(2);
+
+			});
+		}
+
+		@Test
+		@DisplayName("유저가 존재하지 않으면 조회에 실패한다.")
+		void getUserStatus_whenUserNotFound_throwsException() {
+			// given
+			final Long NOT_EXIST_USER_ID = -1L;
+			CustomUserDetails notExistedUserDetails = createCustomUserDetailsByUserId(NOT_EXIST_USER_ID);
+
+			// when & then
+			assertThatThrownBy(() -> userService.getUserStatus(notExistedUserDetails))
+				.isInstanceOf(CommonException.class)
+				.hasMessageContaining(NOT_FOUND_USER.getMessage());
+
+		}
+	}
+
+	@Nested
+	@DisplayName("가장 최근에 접근한 팀스페이스 조회시")
+	class UpdateLastSeenClass {
+
+		@Test
+		@DisplayName("유저가 해당 팀스페이스에 참여하고 있다면 가장 최근에 접근한 팀스페이스 업데이트에 성공한다.")
+		void updateLastSeenTeamspace_updatesLastSeenCorrectly() {
+			// given
+			LastSeenUpdateRequest request = new LastSeenUpdateRequest(osTeamspace.getId());
+			given(teamspaceService.getUserTeamspace(userDetails, osTeamspace.getId())).willReturn(osUserTeamspace);
+			willDoNothing().given(lastSeenTeamspaceService)
+				.updateLastSeenTeamspace(user.getId(), request.teamspaceId());
+
+			// when
+			userService.updateLastSeenTeamspace(userDetails, request);
+
+			// then
+			verify(lastSeenTeamspaceService).updateLastSeenTeamspace(user.getId(), request.teamspaceId());
+			verify(lastSeenTeamspaceService, times(1))
+				.updateLastSeenTeamspace(user.getId(), request.teamspaceId());
+
+		}
+
+		@Test
+		@DisplayName("유저가 해당 팀스페이스에 참여하지 않았다면 업데이트 실패한다.")
+		void updateLastSeenTeamspace_failsIfUserNotPartOfTeamspace() {
+			// given
+			final Long NOT_EXIST_TEAMSPACE_ID = -1L;
+
+			LastSeenUpdateRequest request = new LastSeenUpdateRequest(NOT_EXIST_TEAMSPACE_ID);
+			given(teamspaceService.getUserTeamspace(userDetails, NOT_EXIST_TEAMSPACE_ID))
+				.willThrow(new CommonException(ExceptionCode.FORBIDDEN_TEAMSPACE));
+
+			// when & then
+			assertThatThrownBy(() -> userService.updateLastSeenTeamspace(userDetails, request))
+				.isInstanceOf(CommonException.class)
+				.hasMessageContaining(FORBIDDEN_TEAMSPACE.getMessage());
+
+			verify(lastSeenTeamspaceService, never()).updateLastSeenTeamspace(anyLong(), anyLong());
+		}
+	}
+
+}

--- a/src/test/java/one/colla/user/application/UserServiceTest.java
+++ b/src/test/java/one/colla/user/application/UserServiceTest.java
@@ -26,10 +26,11 @@ import one.colla.infra.redis.lastseen.LastSeenTeamspaceService;
 import one.colla.teamspace.application.TeamspaceService;
 import one.colla.teamspace.domain.Teamspace;
 import one.colla.teamspace.domain.UserTeamspace;
-import one.colla.teamspace.domain.vo.ProfileImageUrl;
+import one.colla.teamspace.domain.vo.TeamspaceProfileImageUrl;
 import one.colla.user.application.dto.request.LastSeenUpdateRequest;
 import one.colla.user.application.dto.response.UserStatusResponse;
 import one.colla.user.domain.User;
+import one.colla.user.domain.vo.UserProfileImageUrl;
 
 public class UserServiceTest extends ServiceTest {
 
@@ -56,12 +57,12 @@ public class UserServiceTest extends ServiceTest {
 	@BeforeEach
 	void setUp() {
 		user = testFixtureBuilder.buildUser(USER1());
-		user.updateProfileImage(new one.colla.user.domain.vo.ProfileImageUrl(USER_PROFILE_IMAGE_URL));
+		user.updateProfileImage(new UserProfileImageUrl(USER_PROFILE_IMAGE_URL));
 		userDetails = createCustomUserDetailsByUser(user);
 		osTeamspace = testFixtureBuilder.buildTeamspace(OS_TEAMSPACE());
 		dbTeamspace = testFixtureBuilder.buildTeamspace(DATABASE_TEAMSPACE());
-		osTeamspace.changeProfileImageUrl(new ProfileImageUrl(OS_TEAMSPACE_PROFILE_IMAGE_URL));
-		dbTeamspace.changeProfileImageUrl(new ProfileImageUrl(DB_TEAMSPACE_PROFILE_IMAGE_URL));
+		osTeamspace.changeProfileImageUrl(new TeamspaceProfileImageUrl(OS_TEAMSPACE_PROFILE_IMAGE_URL));
+		dbTeamspace.changeProfileImageUrl(new TeamspaceProfileImageUrl(DB_TEAMSPACE_PROFILE_IMAGE_URL));
 		osUserTeamspace = testFixtureBuilder.buildUserTeamspace(MEMBER_USERTEAMSPACE(user, osTeamspace));
 		dbUserTeamspace = testFixtureBuilder.buildUserTeamspace(MEMBER_USERTEAMSPACE(user, dbTeamspace));
 	}

--- a/src/test/java/one/colla/user/domain/vo/UserProfileImageUrlTest.java
+++ b/src/test/java/one/colla/user/domain/vo/UserProfileImageUrlTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import one.colla.global.exception.VoException;
 
-public class ProfileImageUrlTest {
+public class UserProfileImageUrlTest {
 
 	@Test
 	@DisplayName("두 객체의 값이 같으면 같은 객체이다.")
@@ -16,8 +16,8 @@ public class ProfileImageUrlTest {
 		String input = "http://example.com/profile.jpg";
 
 		// when
-		ProfileImageUrl url1 = new ProfileImageUrl(input);
-		ProfileImageUrl url2 = new ProfileImageUrl(input);
+		UserProfileImageUrl url1 = new UserProfileImageUrl(input);
+		UserProfileImageUrl url2 = new UserProfileImageUrl(input);
 
 		// then
 		assertThat(url1).isEqualTo(url2);
@@ -31,8 +31,8 @@ public class ProfileImageUrlTest {
 		String input2 = "http://example.com/another.jpg";
 
 		// when
-		ProfileImageUrl url1 = new ProfileImageUrl(input1);
-		ProfileImageUrl url2 = new ProfileImageUrl(input2);
+		UserProfileImageUrl url1 = new UserProfileImageUrl(input1);
+		UserProfileImageUrl url2 = new UserProfileImageUrl(input2);
 
 		// then
 		assertThat(url1).isNotEqualTo(url2);
@@ -45,7 +45,7 @@ public class ProfileImageUrlTest {
 		String validUrl = "http://example.com/profile.jpg";
 
 		// when
-		ProfileImageUrl imageUrl = new ProfileImageUrl(validUrl);
+		UserProfileImageUrl imageUrl = new UserProfileImageUrl(validUrl);
 
 		// then
 		assertThat(imageUrl.getValue()).isEqualTo(validUrl);
@@ -58,7 +58,7 @@ public class ProfileImageUrlTest {
 		String invalidUrl = "htp:/example.com";
 
 		// when/then
-		assertThatThrownBy(() -> new ProfileImageUrl(invalidUrl))
+		assertThatThrownBy(() -> new UserProfileImageUrl(invalidUrl))
 			.isInstanceOf(VoException.class)
 			.hasMessageContaining("url 형식이 아닙니다.");
 	}
@@ -70,7 +70,7 @@ public class ProfileImageUrlTest {
 		String blankUrl = "   ";
 
 		// when/then
-		assertThatThrownBy(() -> new ProfileImageUrl(blankUrl))
+		assertThatThrownBy(() -> new UserProfileImageUrl(blankUrl))
 			.isInstanceOf(VoException.class)
 			.hasMessageContaining("url은 공백일 수 없습니다.");
 	}
@@ -81,10 +81,10 @@ public class ProfileImageUrlTest {
 		// given
 		String initialUrl = "http://example.com/old_profile.jpg";
 		String newUrl = "http://example.com/new_profile.jpg";
-		ProfileImageUrl imageUrl = new ProfileImageUrl(initialUrl);
+		UserProfileImageUrl imageUrl = new UserProfileImageUrl(initialUrl);
 
 		// when
-		ProfileImageUrl updatedImageUrl = imageUrl.change(newUrl);
+		UserProfileImageUrl updatedImageUrl = imageUrl.change(newUrl);
 
 		// then
 		assertThat(updatedImageUrl.getValue()).isNotEqualTo(initialUrl);

--- a/src/test/java/one/colla/user/presentation/UserControllerTest.java
+++ b/src/test/java/one/colla/user/presentation/UserControllerTest.java
@@ -1,0 +1,206 @@
+package one.colla.user.presentation;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static one.colla.common.fixtures.TeamspaceFixtures.*;
+import static one.colla.common.fixtures.UserFixtures.*;
+import static one.colla.common.fixtures.UserTeamspaceFixtures.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+
+import one.colla.common.ControllerTest;
+import one.colla.common.presentation.ApiResponse;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.common.security.authentication.WithMockCustomUser;
+import one.colla.global.exception.CommonException;
+import one.colla.global.exception.ExceptionCode;
+import one.colla.teamspace.domain.Teamspace;
+import one.colla.teamspace.domain.UserTeamspace;
+import one.colla.teamspace.domain.vo.ProfileImageUrl;
+import one.colla.user.application.UserService;
+import one.colla.user.application.dto.request.LastSeenUpdateRequest;
+import one.colla.user.application.dto.response.ParticipatedTeamspaceDto;
+import one.colla.user.application.dto.response.ProfileDto;
+import one.colla.user.application.dto.response.UserStatusResponse;
+import one.colla.user.domain.User;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest extends ControllerTest {
+
+	@MockBean
+	UserService userservice;
+
+	@Nested
+	@DisplayName("팀스페이스 태그 생성 문서화")
+	class getUserStatusDocs {
+		final User user = USER1();
+		final Teamspace osTeamspace = OS_TEAMSPACE();
+		final Teamspace dbTeamspace = DATABASE_TEAMSPACE();
+		final String USER_PROFILE_IMAGE_URL = "http://user-profile-image.com";
+		final String OS_TEAMSPACE_PROFILE_IMAGE_URL = "http://os-profile-image.com";
+		final String DB_TEAMSPACE_PROFILE_IMAGE_URL = "http://db-profile-image.com";
+		final Long userId = 1L;
+		final Long osTeamspaceId = 1L;
+		final Long dbTeamspaceId = 2L;
+		final Long lastSeenTeamspaceId = 2L;
+		final int numOfOsTeamspaceParticipants = 5;
+		final int numOfDbTeamspaceParticipants = 4;
+
+		@Test
+		@DisplayName("사용자 프로필 및 팀스페이스 참여 세부 사항 문서화")
+		@WithMockCustomUser
+		void getUserStatus() throws Exception {
+			user.updateProfileImage(new one.colla.user.domain.vo.ProfileImageUrl(USER_PROFILE_IMAGE_URL));
+			osTeamspace.changeProfileImageUrl(new ProfileImageUrl(OS_TEAMSPACE_PROFILE_IMAGE_URL));
+			dbTeamspace.changeProfileImageUrl(new ProfileImageUrl(DB_TEAMSPACE_PROFILE_IMAGE_URL));
+
+			final UserTeamspace osUserTeamspace = MEMBER_USERTEAMSPACE(user, osTeamspace);
+			final UserTeamspace dbUserTeamspace = MEMBER_USERTEAMSPACE(user, dbTeamspace);
+			final ProfileDto profile = ProfileDto.of(userId, user, lastSeenTeamspaceId);
+			final List<ParticipatedTeamspaceDto> participatedTeamspaceDto = List.of(
+				ParticipatedTeamspaceDto.of(osTeamspaceId, osUserTeamspace, numOfOsTeamspaceParticipants),
+				ParticipatedTeamspaceDto.of(dbTeamspaceId, dbUserTeamspace, numOfDbTeamspaceParticipants)
+			);
+			UserStatusResponse userStatusResponse = UserStatusResponse.of(profile, participatedTeamspaceDto);
+
+			given(userservice.getUserStatus(any(CustomUserDetails.class))).willReturn(userStatusResponse);
+
+			doTest(
+				ApiResponse.createSuccessResponse(userStatusResponse),
+				status().isOk(),
+				apiDocHelper.createSuccessResponseFields(
+					fieldWithPath("profile.userId").description("사용자 ID")
+						.type(JsonFieldType.NUMBER),
+					fieldWithPath("profile.username").description("사용자 이름")
+						.type(JsonFieldType.STRING),
+					fieldWithPath("profile.profileImageUrl").description("프로필 이미지 URL")
+						.type(JsonFieldType.STRING),
+					fieldWithPath("profile.email").description("이메일 주소")
+						.type(JsonFieldType.STRING),
+					fieldWithPath("profile.emailSubscription").description("이메일 구독 여부")
+						.type(JsonFieldType.BOOLEAN),
+					fieldWithPath("profile.commentNotification").description("댓글 알림 설정")
+						.type(JsonFieldType.STRING),
+					fieldWithPath("profile.lastSeenTeamspaceId").description("마지막으로 방문한 팀스페이스 ID")
+						.type(JsonFieldType.NUMBER),
+					fieldWithPath("participatedTeamspaces[].teamspaceId").description("팀스페이스 ID")
+						.type(JsonFieldType.NUMBER),
+					fieldWithPath("participatedTeamspaces[].name").description("팀스페이스 이름")
+						.type(JsonFieldType.STRING),
+					fieldWithPath("participatedTeamspaces[].profileImageUrl").description("팀스페이스 프로필 이미지 URL")
+						.type(JsonFieldType.STRING),
+					fieldWithPath("participatedTeamspaces[].teamspaceRole").description("팀스페이스에서의 역할")
+						.type(JsonFieldType.STRING),
+					fieldWithPath("participatedTeamspaces[].numOfParticipants").description("팀스페이스 참여 인원 수")
+						.type(JsonFieldType.NUMBER)
+				),
+				"ApiResponse<UserStatusResponse>"
+			);
+		}
+
+		private void doTest(
+			ApiResponse<?> response,
+			ResultMatcher statusMatcher,
+			FieldDescriptor[] responseFields,
+			String responseSchemaTitle
+		) throws Exception {
+			mockMvc.perform(get("/api/v1/users/status")
+					.with(csrf()))
+				.andExpect(statusMatcher)
+				.andExpect(content().json(objectMapper.writeValueAsString(response)))
+				.andDo(restDocs.document(
+					resource(ResourceSnippetParameters.builder()
+						.tag("user-controller")
+						.description("사용자 프로필과 팀스페이스 참여 세부사항을 조회합니다.")
+						.responseFields(responseFields)
+						.responseSchema(Schema.schema(responseSchemaTitle))
+						.build()
+					)))
+				.andDo(print());
+
+		}
+
+	}
+
+	@Nested
+	@DisplayName("마지막으로 본 팀스페이스 업데이트 문서화")
+	class UpdateLastSeenDoc {
+		Long teamSpaceId = 1L;
+		LastSeenUpdateRequest request = new LastSeenUpdateRequest(teamSpaceId);
+
+		@Test
+		@DisplayName("마지막으로 본 팀스페이스 Id를 업데이트 할 수 있다.")
+		@WithMockCustomUser
+		void updateLastSeenTeamspace_Success() throws Exception {
+			willDoNothing().given(userservice).updateLastSeenTeamspace(any(CustomUserDetails.class), eq(request));
+			doTest(
+				ApiResponse.createSuccessResponse(Map.of()),
+				status().isOk(),
+				apiDocHelper.createSuccessResponseFields(),
+				"ApiResponse"
+			);
+
+		}
+
+		@Test
+		@DisplayName("참여하지 않은 팀스페이스 Id로 업데이트 할 수 없다.")
+		@WithMockCustomUser
+		void updateLastSeenTeamspace_Fail() throws Exception {
+			willThrow(new CommonException(ExceptionCode.FORBIDDEN_TEAMSPACE)).given(userservice)
+				.updateLastSeenTeamspace(any(CustomUserDetails.class), eq(request));
+
+			doTest(
+				ApiResponse.createErrorResponse(ExceptionCode.FORBIDDEN_TEAMSPACE),
+				status().isForbidden(),
+				apiDocHelper.createErrorResponseFields(),
+				"ApiResponse"
+			);
+
+		}
+
+		private void doTest(
+			ApiResponse<?> response,
+			ResultMatcher statusMatcher,
+			FieldDescriptor[] responseFields,
+			String responseSchemaTitle
+		) throws Exception {
+			mockMvc.perform(post("/api/v1/users/last-seen")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request))
+					.with(csrf()))
+				.andExpect(statusMatcher)
+				.andExpect(content().json(objectMapper.writeValueAsString(response)))
+				.andDo(restDocs.document(
+					resource(ResourceSnippetParameters.builder()
+						.tag("user-controller")
+						.description("사용자가 마지막으로 본 팀스페이스 Id를 업데이트 합니다.")
+						.responseFields(responseFields)
+						.responseSchema(Schema.schema(responseSchemaTitle))
+						.build()
+					)))
+				.andDo(print());
+
+		}
+
+	}
+
+}

--- a/src/test/java/one/colla/user/presentation/UserControllerTest.java
+++ b/src/test/java/one/colla/user/presentation/UserControllerTest.java
@@ -35,13 +35,14 @@ import one.colla.global.exception.CommonException;
 import one.colla.global.exception.ExceptionCode;
 import one.colla.teamspace.domain.Teamspace;
 import one.colla.teamspace.domain.UserTeamspace;
-import one.colla.teamspace.domain.vo.ProfileImageUrl;
+import one.colla.teamspace.domain.vo.TeamspaceProfileImageUrl;
 import one.colla.user.application.UserService;
 import one.colla.user.application.dto.request.LastSeenUpdateRequest;
 import one.colla.user.application.dto.response.ParticipatedTeamspaceDto;
 import one.colla.user.application.dto.response.ProfileDto;
 import one.colla.user.application.dto.response.UserStatusResponse;
 import one.colla.user.domain.User;
+import one.colla.user.domain.vo.UserProfileImageUrl;
 
 @WebMvcTest(UserController.class)
 class UserControllerTest extends ControllerTest {
@@ -69,9 +70,9 @@ class UserControllerTest extends ControllerTest {
 		@DisplayName("사용자 프로필 및 팀스페이스 참여 세부 사항 문서화")
 		@WithMockCustomUser
 		void getUserStatus() throws Exception {
-			user.updateProfileImage(new one.colla.user.domain.vo.ProfileImageUrl(USER_PROFILE_IMAGE_URL));
-			osTeamspace.changeProfileImageUrl(new ProfileImageUrl(OS_TEAMSPACE_PROFILE_IMAGE_URL));
-			dbTeamspace.changeProfileImageUrl(new ProfileImageUrl(DB_TEAMSPACE_PROFILE_IMAGE_URL));
+			user.updateProfileImage(new UserProfileImageUrl(USER_PROFILE_IMAGE_URL));
+			osTeamspace.changeProfileImageUrl(new TeamspaceProfileImageUrl(OS_TEAMSPACE_PROFILE_IMAGE_URL));
+			dbTeamspace.changeProfileImageUrl(new TeamspaceProfileImageUrl(DB_TEAMSPACE_PROFILE_IMAGE_URL));
 
 			final UserTeamspace osUserTeamspace = MEMBER_USERTEAMSPACE(user, osTeamspace);
 			final UserTeamspace dbUserTeamspace = MEMBER_USERTEAMSPACE(user, dbTeamspace);


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-backend/issues/36

## ✨ PR 세부 내용

- 사용자 프로필 조회 및 팀스페이스 참여 세부사항 조회 API 개발
- 가장 최근에 접근한 팀스페이스 업데이트 API 개발
- 이름이 중복되거나 명확하지 않은 Class Name 리팩토링
- profileImageUrl을 찾지 못하는 에러 해결
- login 응답 필드에 팀 참여 여부 필드 추가
- swagger security 헤더에 Bearer token 추가

## 📸 스크린샷
![스크린샷 2024-05-08 오전 5 04 19](https://github.com/98OO/colla-backend/assets/67590577/f704e208-5c62-476b-9471-da790f26bd12)

## ✅ 리뷰 요구사항
- 질문있으시면 댓글 남겨주세요!
- 이슈를 새로 파서 진행해야 하는 작업들을 한번에 해버렸네요... 다음부턴 주의하겠습니다!
