### PR TITLE
마이페이지 설정 관련 api 개발

### DIFF
--- a/src/main/java/one/colla/teamspace/application/TeamspaceService.java
+++ b/src/main/java/one/colla/teamspace/application/TeamspaceService.java
@@ -242,6 +242,20 @@ public class TeamspaceService {
 		log.info("팀 스페이스 설정 업데이트 - 팀 스페이스 Id: {}, 사용자 Id: {}", teamspaceId, userDetails.getUserId());
 	}
 
+	@Transactional
+	public void deleteProfileImageUrl(CustomUserDetails userDetails, Long teamspaceId) {
+		UserTeamspace userTeamspace = getUserTeamspace(userDetails, teamspaceId);
+
+		if (userTeamspace.getTeamspaceRole() != TeamspaceRole.LEADER) {
+			throw new CommonException(ExceptionCode.ONLY_LEADER_ACCESS);
+		}
+
+		Teamspace teamspace = userTeamspace.getTeamspace();
+		teamspace.deleteProfileImageUrl();
+
+		log.info("팀스페이스 프로필 사진 삭제 완료 - 팀 스페이스 Id: {} 사용자 Id: {}", teamspace, userDetails.getUserId());
+	}
+
 	private Pair<InviteCode, UserTeamspace> generateAndSaveInviteCodeByTeamspaceId(CustomUserDetails userDetails,
 		Long teamspaceId) {
 		UserTeamspace userTeamspace = getUserTeamspace(userDetails, teamspaceId);

--- a/src/main/java/one/colla/teamspace/domain/Teamspace.java
+++ b/src/main/java/one/colla/teamspace/domain/Teamspace.java
@@ -87,4 +87,8 @@ public class Teamspace extends BaseEntity {
 	public void changeProfileImageUrl(final TeamspaceProfileImageUrl teamspaceProfileImageUrl) {
 		this.teamspaceProfileImageUrl = teamspaceProfileImageUrl;
 	}
+
+	public void deleteProfileImageUrl() {
+		this.teamspaceProfileImageUrl = null;
+	}
 }

--- a/src/main/java/one/colla/teamspace/presentation/TeamspaceController.java
+++ b/src/main/java/one/colla/teamspace/presentation/TeamspaceController.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -138,6 +139,16 @@ public class TeamspaceController {
 		@RequestBody @Valid final UpdateTeamspaceSettingsRequest request
 	) {
 		teamspaceService.updateSettings(userDetails, teamspaceId, request);
+		return ResponseEntity.ok().body(ApiResponse.createSuccessResponse(Map.of()));
+	}
+
+	@DeleteMapping("/{teamspaceId}/settings/profile-image")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Object>> deleteTeamspaceProfileImageUrl(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final Long teamspaceId
+	) {
+		teamspaceService.deleteProfileImageUrl(userDetails, teamspaceId);
 		return ResponseEntity.ok().body(ApiResponse.createSuccessResponse(Map.of()));
 	}
 }

--- a/src/main/java/one/colla/user/application/UserService.java
+++ b/src/main/java/one/colla/user/application/UserService.java
@@ -16,11 +16,14 @@ import one.colla.infra.redis.lastseen.LastSeenTeamspaceService;
 import one.colla.teamspace.application.TeamspaceService;
 import one.colla.teamspace.domain.UserTeamspace;
 import one.colla.user.application.dto.request.LastSeenUpdateRequest;
+import one.colla.user.application.dto.request.UpdateUserSettingRequest;
 import one.colla.user.application.dto.response.ParticipatedTeamspaceDto;
 import one.colla.user.application.dto.response.ProfileDto;
 import one.colla.user.application.dto.response.UserStatusResponse;
 import one.colla.user.domain.User;
 import one.colla.user.domain.UserRepository;
+import one.colla.user.domain.vo.UserProfileImageUrl;
+import one.colla.user.domain.vo.Username;
 
 @Service
 @RequiredArgsConstructor
@@ -75,6 +78,33 @@ public class UserService {
 			.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_USER));
 
 		return !user.getUserTeamspaces().isEmpty();
+	}
+
+	@Transactional
+	public void updateSettings(CustomUserDetails userDetails, UpdateUserSettingRequest request) {
+		final User user = userRepository.findById(userDetails.getUserId())
+			.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_USER));
+
+		if (request.profileImageUrl() != null) {
+			UserProfileImageUrl userProfileImageUrl = UserProfileImageUrl.from(request.profileImageUrl());
+			user.changeProfileImageUrl(userProfileImageUrl);
+		}
+
+		if (request.emailSubscription() != null) {
+			log.debug(request.emailSubscription().toString());
+			user.changeEmailSubscription(request.emailSubscription());
+		}
+
+		if (request.commentNotification() != null) {
+			user.changeCommentNotification(request.commentNotification());
+		}
+
+		if (request.username() != null) {
+			Username username = Username.from(request.username());
+			user.changeUsername(username);
+		}
+
+		log.info("사용자 설정 업데이트 - 사용자 Id: {}", userDetails.getUserId());
 	}
 
 	private int getNumOfTeamspaceParticipants(UserTeamspace userTeamspace) {

--- a/src/main/java/one/colla/user/application/UserService.java
+++ b/src/main/java/one/colla/user/application/UserService.java
@@ -107,6 +107,15 @@ public class UserService {
 		log.info("사용자 설정 업데이트 - 사용자 Id: {}", userDetails.getUserId());
 	}
 
+	@Transactional
+	public void deleteProfileImageUrl(CustomUserDetails userDetails) {
+		final User user = userRepository.findById(userDetails.getUserId())
+			.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_USER));
+
+		user.deleteProfileImageUrl();
+		log.info("사용자 프로필 사진 삭제 완료 - 사용자 Id: {}", userDetails.getUserId());
+	}
+
 	private int getNumOfTeamspaceParticipants(UserTeamspace userTeamspace) {
 		return userTeamspace.getTeamspace()
 			.getUserTeamspaces()

--- a/src/main/java/one/colla/user/application/dto/request/UpdateUserSettingRequest.java
+++ b/src/main/java/one/colla/user/application/dto/request/UpdateUserSettingRequest.java
@@ -1,0 +1,24 @@
+package one.colla.user.application.dto.request;
+
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.URL;
+
+import jakarta.annotation.Nullable;
+import one.colla.user.domain.CommentNotification;
+
+public record UpdateUserSettingRequest(
+	@Nullable
+	@URL(message = "프로필 이미지 URL 형식이 올바르지 않습니다.")
+	String profileImageUrl,
+
+	@Nullable
+	@Length(min = 2, max = 50, message = "닉네임은 2자 이상 50자 이하이어야 합니다.")
+	String username,
+
+	@Nullable
+	Boolean emailSubscription,
+
+	@Nullable
+	CommentNotification commentNotification
+) {
+}

--- a/src/main/java/one/colla/user/domain/User.java
+++ b/src/main/java/one/colla/user/domain/User.java
@@ -171,4 +171,8 @@ public class User extends BaseEntity {
 	public void changeProfileImageUrl(final UserProfileImageUrl userProfileImageUrl) {
 		this.userProfileImageUrl = userProfileImageUrl;
 	}
+
+	public void deleteProfileImageUrl() {
+		this.userProfileImageUrl = null;
+	}
 }

--- a/src/main/java/one/colla/user/domain/User.java
+++ b/src/main/java/one/colla/user/domain/User.java
@@ -146,10 +146,6 @@ public class User extends BaseEntity {
 		return userProfileImageUrl != null ? userProfileImageUrl.getValue() : null;
 	}
 
-	public void updateProfileImage(UserProfileImageUrl newUserProfileImageUrl) {
-		this.userProfileImageUrl = newUserProfileImageUrl;
-	}
-
 	public UserTeamspace participate(
 		final Teamspace teamspace,
 		final TeamspaceRole teamspaceRole
@@ -158,5 +154,21 @@ public class User extends BaseEntity {
 		userTeamspaces.add(userTeamspace);
 		teamspace.addUserTeamspace(userTeamspace);
 		return userTeamspace;
+	}
+
+	public void changeUsername(final Username username) {
+		this.username = username;
+	}
+
+	public void changeEmailSubscription(final boolean emailSubscription) {
+		this.emailSubscription = emailSubscription;
+	}
+
+	public void changeCommentNotification(final CommentNotification commentNotification) {
+		this.commentNotification = commentNotification;
+	}
+
+	public void changeProfileImageUrl(final UserProfileImageUrl userProfileImageUrl) {
+		this.userProfileImageUrl = userProfileImageUrl;
 	}
 }

--- a/src/main/java/one/colla/user/presentation/UserController.java
+++ b/src/main/java/one/colla/user/presentation/UserController.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,7 +39,7 @@ public class UserController {
 
 	@PostMapping("/last-seen")
 	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<ApiResponse<?>> updateLastSeenTeamspace(
+	public ResponseEntity<ApiResponse<Object>> updateLastSeenTeamspace(
 		@AuthenticationPrincipal CustomUserDetails userDetails,
 		@RequestBody @Valid final LastSeenUpdateRequest request) {
 		userService.updateLastSeenTeamspace(userDetails, request);
@@ -48,11 +49,20 @@ public class UserController {
 
 	@PatchMapping("/settings")
 	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<ApiResponse<?>> updateUserSettings(
+	public ResponseEntity<ApiResponse<Object>> updateUserSettings(
 		@AuthenticationPrincipal final CustomUserDetails userDetails,
 		@RequestBody @Valid final UpdateUserSettingRequest request
 	) {
 		userService.updateSettings(userDetails, request);
+		return ResponseEntity.ok().body(ApiResponse.createSuccessResponse(Map.of()));
+	}
+
+	@DeleteMapping("/settings/profile-image")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Object>> deleteUserProfileImage(
+		@AuthenticationPrincipal final CustomUserDetails userDetails
+	) {
+		userService.deleteProfileImageUrl(userDetails);
 		return ResponseEntity.ok().body(ApiResponse.createSuccessResponse(Map.of()));
 	}
 }

--- a/src/main/java/one/colla/user/presentation/UserController.java
+++ b/src/main/java/one/colla/user/presentation/UserController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +18,7 @@ import one.colla.common.presentation.ApiResponse;
 import one.colla.common.security.authentication.CustomUserDetails;
 import one.colla.user.application.UserService;
 import one.colla.user.application.dto.request.LastSeenUpdateRequest;
+import one.colla.user.application.dto.request.UpdateUserSettingRequest;
 import one.colla.user.application.dto.response.UserStatusResponse;
 
 @RestController
@@ -44,4 +46,13 @@ public class UserController {
 		);
 	}
 
+	@PatchMapping("/settings")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<?>> updateUserSettings(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@RequestBody @Valid final UpdateUserSettingRequest request
+	) {
+		userService.updateSettings(userDetails, request);
+		return ResponseEntity.ok().body(ApiResponse.createSuccessResponse(Map.of()));
+	}
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   profiles:
-    default: local
+    default: local  # local을 기본 프로필로 설정
+
   application:
     name:
       colla-backend
@@ -64,8 +65,6 @@ spring:
       token-uri: https://nid.naver.com/oauth2.0/token
       redirect-uri: ${NAVER_REDIRECT_URI}
 
-
-
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
@@ -84,8 +83,9 @@ jwt:
 
 ---
 spring:
-  profiles:
-    default: prod
+  config:
+    activate:
+      on-profile: prod
   application:
     name:
       colla-backend
@@ -118,6 +118,34 @@ spring:
     password: ${MAIL_PASSWORD}
     admin-email: ${MAIL_ADMIN_EMAIL}
 
+  oauth:
+    google:
+      client-id: ${GOOGLE_CLIENT_ID}
+      client-secret: ${GOOGLE_CLIENT_SECRET}
+      end-point: https://accounts.google.com/o/oauth2/v2/auth
+      response-type: code
+      access-type: ${GOOGLE_ACCESS_TYPE}
+      scopes: ${GOOGLE_SCOPE}
+      token-uri: https://oauth2.googleapis.com/token
+      redirect-uri: ${GOOGLE_REDIRECT_URI}
+    kakao:
+      client-id: ${KAKAO_CLIENT_ID}
+      client-secret: ${KAKAO_CLIENT_SECRET}
+      end-point: https://kauth.kakao.com/oauth/authorize
+      response-type: code
+      access-type: ${KAKAO_ACCESS_TYPE}
+      scopes: ${KAKAO_SCOPE}
+      token-uri: https://kauth.kakao.com/oauth/token
+      redirect-uri: ${KAKAO_REDIRECT_URI}
+    naver:
+      client-id: ${NAVER_CLIENT_ID}
+      client-secret: ${NAVER_CLIENT_SECRET}
+      end-point: https://nid.naver.com/oauth2.0/authorize
+      response-type: code
+      access-type: ${NAVER_ACCESS_TYPE}
+      scopes: ${NAVER_SCOPE}
+      token-uri: https://nid.naver.com/oauth2.0/token
+      redirect-uri: ${NAVER_REDIRECT_URI}
 
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8

--- a/src/test/java/one/colla/teamspace/application/TeamspaceServiceTest.java
+++ b/src/test/java/one/colla/teamspace/application/TeamspaceServiceTest.java
@@ -582,7 +582,7 @@ class TeamspaceServiceTest extends ServiceTest {
 	}
 
 	@Nested
-	@DisplayName("팀스페이스 태그 생성 시")
+	@DisplayName("팀스페이스 설정 시")
 	class UpdateSettingsTest {
 		User USER1;
 		CustomUserDetails USER1_DETAILS;

--- a/src/test/java/one/colla/teamspace/application/TeamspaceServiceTest.java
+++ b/src/test/java/one/colla/teamspace/application/TeamspaceServiceTest.java
@@ -48,6 +48,7 @@ import one.colla.teamspace.domain.TeamspaceRepository;
 import one.colla.teamspace.domain.TeamspaceRole;
 import one.colla.teamspace.domain.UserTeamspace;
 import one.colla.teamspace.domain.UserTeamspaceRepository;
+import one.colla.teamspace.domain.vo.TeamspaceProfileImageUrl;
 import one.colla.user.domain.User;
 
 class TeamspaceServiceTest extends ServiceTest {
@@ -662,5 +663,59 @@ class TeamspaceServiceTest extends ServiceTest {
 				.isExactlyInstanceOf(CommonException.class)
 				.hasMessageContaining(ExceptionCode.FAIL_CHANGE_USERTAG.getMessage());
 		}
+	}
+
+	@Nested
+	@DisplayName("팀스페이스 프로필 사진 삭제 시")
+	class deleteProfileImageUrlTest {
+		User USER1;
+		CustomUserDetails USER1_DETAILS;
+		Teamspace OS_TEAMSPACE;
+		UserTeamspace USER1_OS_USERTEAMSPACE;
+		Tag FRONTEND_TAG;
+
+		@BeforeEach
+		void setUp() {
+			// given
+			USER1 = testFixtureBuilder.buildUser(USER1());
+			USER1_DETAILS = createCustomUserDetailsByUser(USER1);
+
+			OS_TEAMSPACE = testFixtureBuilder.buildTeamspace(OS_TEAMSPACE());
+
+			USER1_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(
+				LEADER_USERTEAMSPACE(USER1, OS_TEAMSPACE));
+
+			FRONTEND_TAG = testFixtureBuilder.buildTag(FRONTEND_TAG(OS_TEAMSPACE));
+		}
+
+		@Test
+		@DisplayName("삭제에 성공한다.")
+		void updateSettingsSuccessfully() {
+			final String PROFILE_URL = "https://example.com";
+
+			// given
+			OS_TEAMSPACE.changeProfileImageUrl(new TeamspaceProfileImageUrl(PROFILE_URL));
+
+			// when
+			teamspaceService.deleteProfileImageUrl(USER1_DETAILS, OS_TEAMSPACE.getId());
+
+			// then
+			assertThat(OS_TEAMSPACE.getProfileImageUrlValue()).isNull();
+		}
+
+		@Test
+		@DisplayName("팀스페이스 리더가 아닌 사용자면 예외가 발생한다.")
+		void updateSettingsNotLeaderFailure() {
+			// given
+			User USER2 = testFixtureBuilder.buildUser(USER2());
+			CustomUserDetails USER2_DETAILS = createCustomUserDetailsByUser(USER2);
+			testFixtureBuilder.buildUserTeamspace(MEMBER_USERTEAMSPACE(USER2, OS_TEAMSPACE));
+
+			// when then
+			assertThatThrownBy(() -> teamspaceService.deleteProfileImageUrl(USER2_DETAILS, OS_TEAMSPACE.getId()))
+				.isExactlyInstanceOf(CommonException.class)
+				.hasMessageContaining(ExceptionCode.ONLY_LEADER_ACCESS.getMessage());
+		}
+
 	}
 }

--- a/src/test/java/one/colla/teamspace/application/dto/UpdateTeamspaceSettingsRequestValidationTest.java
+++ b/src/test/java/one/colla/teamspace/application/dto/UpdateTeamspaceSettingsRequestValidationTest.java
@@ -10,17 +10,13 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 import jakarta.validation.ConstraintViolation;
+import one.colla.common.CommonTest;
 import one.colla.teamspace.application.dto.request.UpdateTeamspaceSettingsRequest;
 
-@SpringBootTest
-@ActiveProfiles("test")
-class UpdateTeamspaceSettingsRequestValidationTest {
-
+class UpdateTeamspaceSettingsRequestValidationTest extends CommonTest {
 	@Autowired
 	private LocalValidatorFactoryBean validator;
 

--- a/src/test/java/one/colla/teamspace/presentation/TeamspaceControllerTest.java
+++ b/src/test/java/one/colla/teamspace/presentation/TeamspaceControllerTest.java
@@ -596,7 +596,7 @@ class TeamspaceControllerTest extends ControllerTest {
 				ApiResponse.createSuccessResponse(Map.of()),
 				status().isOk(),
 				apiDocHelper.createSuccessResponseFields(),
-				"ApiResponse<UpdateTeamspaceSettings>"
+				"ApiResponse"
 			);
 		}
 

--- a/src/test/java/one/colla/teamspace/presentation/TeamspaceControllerTest.java
+++ b/src/test/java/one/colla/teamspace/presentation/TeamspaceControllerTest.java
@@ -650,4 +650,49 @@ class TeamspaceControllerTest extends ControllerTest {
 				.andDo(print());
 		}
 	}
+
+	@Nested
+	@DisplayName("팀스페이스 프로필 사진 삭제 문서화")
+	class DeleteTeamspaceProfileImageUrlDocs {
+		Long teamspaceId = 1L;
+
+		@Test
+		@WithMockCustomUser
+		@DisplayName("팀스페이스 설정 수정 성공")
+		void updateTeamspaceSettingsSuccessfully() throws Exception {
+			doNothing().when(teamspaceService).deleteProfileImageUrl(any(CustomUserDetails.class), eq(teamspaceId));
+
+			doTest(
+				ApiResponse.createSuccessResponse(Map.of()),
+				status().isOk(),
+				apiDocHelper.createSuccessResponseFields(),
+				"ApiResponse"
+			);
+		}
+
+		private void doTest(
+			ApiResponse<?> response,
+			ResultMatcher statusMatcher,
+			FieldDescriptor[] responseFields,
+			String responseSchemaTitle
+		) throws Exception {
+			mockMvc.perform(delete("/api/v1/teamspaces/{teamspaceId}/settings/profile-image", teamspaceId)
+					.contentType(MediaType.APPLICATION_JSON)
+					.with(csrf()))
+				.andExpect(statusMatcher)
+				.andExpect(content().json(objectMapper.writeValueAsString(response)))
+				.andDo(restDocs.document(
+					resource(ResourceSnippetParameters.builder()
+						.tag("teamspace-controller")
+						.description("특정 팀스페이스의 프로필 사진을 삭제합니다.")
+						.pathParameters(
+							parameterWithName("teamspaceId").description("팀스페이스의 고유 식별자")
+						)
+						.responseFields(responseFields)
+						.responseSchema(Schema.schema(responseSchemaTitle))
+						.build()
+					)))
+				.andDo(print());
+		}
+	}
 }

--- a/src/test/java/one/colla/user/application/UpdateUserSettingRequestValidationTest.java
+++ b/src/test/java/one/colla/user/application/UpdateUserSettingRequestValidationTest.java
@@ -1,0 +1,150 @@
+package one.colla.user.application;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+import jakarta.validation.ConstraintViolation;
+import one.colla.common.CommonTest;
+import one.colla.user.application.dto.request.UpdateUserSettingRequest;
+import one.colla.user.domain.CommentNotification;
+
+class UpdateUserSettingRequestValidationTest extends CommonTest {
+	@Autowired
+	private LocalValidatorFactoryBean validator;
+
+	UpdateUserSettingRequest request;
+	Set<ConstraintViolation<UpdateUserSettingRequest>> violations;
+
+	@Test
+	@DisplayName("모든 값이 Null일 수 있다")
+	void testAllValuesCanBeNull() {
+		// given
+		request = new UpdateUserSettingRequest(null, null, null, null);
+
+		// when
+		violations = validator.validate(request);
+
+		// then
+		assertThat(violations).isEmpty();
+	}
+
+	@Test
+	@DisplayName("ProfileImageUrl 이 유효한 URL 형식이면 Validation 에 성공한다")
+	void testProfileImageUrlValid() {
+		// given
+		request = new UpdateUserSettingRequest("https://www.example.com", null, null, null);
+
+		// when
+		violations = validator.validate(request);
+
+		// then
+		assertThat(violations).isEmpty();
+	}
+
+	@Test
+	@DisplayName("ProfileImageUrl 이 유효하지 않은 URL 형식일 때 예외가 발생한다")
+	void testProfileImageUrlInvalid() {
+		// given
+		request = new UpdateUserSettingRequest("htp://example", null, null, null);
+
+		// when
+		violations = validator.validate(request);
+
+		// then
+		assertThat(violations).isNotEmpty();
+		assertThat(violations.iterator().next().getMessage()).isEqualTo("프로필 이미지 URL 형식이 올바르지 않습니다.");
+	}
+
+	@Test
+	@DisplayName("Username 이 유효한 길이 범위 내에 있으면 Validation에 성공한다")
+	void testUsernameLengthValid() {
+		// given
+		request = new UpdateUserSettingRequest(null, "유효한닉네임", null, null);
+
+		// when
+		violations = validator.validate(request);
+
+		// then
+		assertThat(violations).isEmpty();
+	}
+
+	@Test
+	@DisplayName("Username 길이가 유효 범위를 벗어나면 예외가 발생한다")
+	void testUsernameLengthInvalid() {
+		// given
+		request = new UpdateUserSettingRequest(null, "닉", null, null);
+
+		// when
+		violations = validator.validate(request);
+
+		// then
+		assertThat(violations).isNotEmpty();
+		assertThat(violations.iterator().next().getMessage()).isEqualTo("닉네임은 2자 이상 50자 이하이어야 합니다.");
+	}
+
+	@Test
+	@DisplayName("이메일 구독 여부가 설정되어 있으면 Validation에 성공한다")
+	void testEmailSubscriptionSet() {
+		// given
+		request = new UpdateUserSettingRequest(null, null, true, null);
+
+		// when
+		violations = validator.validate(request);
+
+		// then
+		assertThat(violations).isEmpty();
+	}
+
+	@Test
+	@DisplayName("CommentNotification이 설정되어 있으면 Validation에 성공한다")
+	void testCommentNotificationSet() {
+		request = new UpdateUserSettingRequest(null, null, null, CommentNotification.ALL);
+
+		// when
+		violations = validator.validate(request);
+
+		// then
+		assertThat(violations).isEmpty();
+	}
+
+	@Test
+	@DisplayName("모든 필드가 유효할 때 Validation에 성공한다")
+	void testAllFieldsValid() {
+		// given
+		request = new UpdateUserSettingRequest("https://www.example.com", "유효한닉네임", true, CommentNotification.ALL);
+
+		// when
+		violations = validator.validate(request);
+
+		// then
+		assertThat(violations).isEmpty();
+	}
+
+	@Test
+	@DisplayName("여러 필드가 동시에 유효하지 않을 때 여러 예외가 발생한다")
+	void testMultipleFieldsInvalid() {
+		// given
+		request = new UpdateUserSettingRequest("htttp://bad-url", "x", null, null);
+
+		// when
+		violations = validator.validate(request);
+
+		// then
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(violations).hasSize(2);
+			Set<String> messages = violations.stream()
+				.map(ConstraintViolation::getMessage)
+				.collect(Collectors.toSet());
+			softly.assertThat(messages).contains("프로필 이미지 URL 형식이 올바르지 않습니다.");
+			softly.assertThat(messages).contains("닉네임은 2자 이상 50자 이하이어야 합니다.");
+		});
+	}
+}

--- a/src/test/java/one/colla/user/application/UserServiceTest.java
+++ b/src/test/java/one/colla/user/application/UserServiceTest.java
@@ -28,7 +28,9 @@ import one.colla.teamspace.domain.Teamspace;
 import one.colla.teamspace.domain.UserTeamspace;
 import one.colla.teamspace.domain.vo.TeamspaceProfileImageUrl;
 import one.colla.user.application.dto.request.LastSeenUpdateRequest;
+import one.colla.user.application.dto.request.UpdateUserSettingRequest;
 import one.colla.user.application.dto.response.UserStatusResponse;
+import one.colla.user.domain.CommentNotification;
 import one.colla.user.domain.User;
 import one.colla.user.domain.vo.UserProfileImageUrl;
 
@@ -57,7 +59,7 @@ public class UserServiceTest extends ServiceTest {
 	@BeforeEach
 	void setUp() {
 		user = testFixtureBuilder.buildUser(USER1());
-		user.updateProfileImage(new UserProfileImageUrl(USER_PROFILE_IMAGE_URL));
+		user.changeProfileImageUrl(new UserProfileImageUrl(USER_PROFILE_IMAGE_URL));
 		userDetails = createCustomUserDetailsByUser(user);
 		osTeamspace = testFixtureBuilder.buildTeamspace(OS_TEAMSPACE());
 		dbTeamspace = testFixtureBuilder.buildTeamspace(DATABASE_TEAMSPACE());
@@ -155,4 +157,66 @@ public class UserServiceTest extends ServiceTest {
 		}
 	}
 
+	@Nested
+	@DisplayName("사용자 설정 업데이트시")
+	class UpdateSettingsTest {
+		final String NEW_IMAGE_URL = "https://www.example.com/image";
+		final String NEW_USERNAME = "new_username";
+		final Boolean NEW_EMAIL_SUBSCRIPTION = false;
+		final CommentNotification NEW_COMMENT_NOTIFICATION = CommentNotification.MENTION;
+
+		@Test
+		@DisplayName("유저 정보 업데이트에 성공한다.")
+		void updateSettings_successfullyUpdatesUserInfo() {
+			// given
+			UpdateUserSettingRequest request = new UpdateUserSettingRequest(
+				NEW_IMAGE_URL,
+				NEW_USERNAME,
+				NEW_EMAIL_SUBSCRIPTION,
+				NEW_COMMENT_NOTIFICATION
+			);
+
+			// when
+			userService.updateSettings(userDetails, request);
+
+			// then
+			assertSoftly(softly -> {
+				softly.assertThat(user.getProfileImageUrlValue()).isEqualTo(NEW_IMAGE_URL);
+				softly.assertThat(user.getUsernameValue()).isEqualTo(NEW_USERNAME);
+				softly.assertThat(user.isEmailSubscription()).isEqualTo(NEW_EMAIL_SUBSCRIPTION);
+				softly.assertThat(user.getCommentNotification()).isEqualTo(NEW_COMMENT_NOTIFICATION);
+			});
+		}
+
+		@Test
+		@DisplayName("유저가 존재하지 않을 경우 예외가 발생한다.")
+		void updateSettings_throwsExceptionWhenUserNotFound() {
+			// given
+			CustomUserDetails userDetails = createCustomUserDetailsByUserId(-1L);
+			UpdateUserSettingRequest request = new UpdateUserSettingRequest(
+				NEW_IMAGE_URL,
+				NEW_USERNAME,
+				NEW_EMAIL_SUBSCRIPTION,
+				NEW_COMMENT_NOTIFICATION
+			);
+
+			// when then
+			assertThatThrownBy(() -> userService.updateSettings(userDetails, request))
+				.isInstanceOf(CommonException.class)
+				.hasMessageContaining(NOT_FOUND_USER.getMessage());
+		}
+
+		@Test
+		@DisplayName("유저 프로필 이미지만 업데이트 할 수 있다.")
+		void updateSettings_updatesOnlyProfileImage() {
+			// given
+			UpdateUserSettingRequest request = new UpdateUserSettingRequest(NEW_IMAGE_URL, null, null, null);
+
+			// when
+			userService.updateSettings(userDetails, request);
+
+			// then
+			assertThat(user.getProfileImageUrlValue()).isEqualTo(NEW_IMAGE_URL);
+		}
+	}
 }

--- a/src/test/java/one/colla/user/application/UserServiceTest.java
+++ b/src/test/java/one/colla/user/application/UserServiceTest.java
@@ -219,4 +219,18 @@ public class UserServiceTest extends ServiceTest {
 			assertThat(user.getProfileImageUrlValue()).isEqualTo(NEW_IMAGE_URL);
 		}
 	}
+
+	@Nested
+	@DisplayName("사용자 프로필 이미지 삭제 시")
+	class DeleteProfileImageUrlTest {
+		@Test
+		@DisplayName("삭제에 성공한다.")
+		void deleteProfileImageUrlSuccessfully() {
+			// when
+			userService.deleteProfileImageUrl(userDetails);
+
+			// then
+			assertThat(user.getProfileImageUrlValue()).isNull();
+		}
+	}
 }

--- a/src/test/java/one/colla/user/presentation/UserControllerTest.java
+++ b/src/test/java/one/colla/user/presentation/UserControllerTest.java
@@ -38,9 +38,11 @@ import one.colla.teamspace.domain.UserTeamspace;
 import one.colla.teamspace.domain.vo.TeamspaceProfileImageUrl;
 import one.colla.user.application.UserService;
 import one.colla.user.application.dto.request.LastSeenUpdateRequest;
+import one.colla.user.application.dto.request.UpdateUserSettingRequest;
 import one.colla.user.application.dto.response.ParticipatedTeamspaceDto;
 import one.colla.user.application.dto.response.ProfileDto;
 import one.colla.user.application.dto.response.UserStatusResponse;
+import one.colla.user.domain.CommentNotification;
 import one.colla.user.domain.User;
 import one.colla.user.domain.vo.UserProfileImageUrl;
 
@@ -48,7 +50,7 @@ import one.colla.user.domain.vo.UserProfileImageUrl;
 class UserControllerTest extends ControllerTest {
 
 	@MockBean
-	UserService userservice;
+	UserService userService;
 
 	@Nested
 	@DisplayName("팀스페이스 태그 생성 문서화")
@@ -70,7 +72,7 @@ class UserControllerTest extends ControllerTest {
 		@DisplayName("사용자 프로필 및 팀스페이스 참여 세부 사항 문서화")
 		@WithMockCustomUser
 		void getUserStatus() throws Exception {
-			user.updateProfileImage(new UserProfileImageUrl(USER_PROFILE_IMAGE_URL));
+			user.changeProfileImageUrl(new UserProfileImageUrl(USER_PROFILE_IMAGE_URL));
 			osTeamspace.changeProfileImageUrl(new TeamspaceProfileImageUrl(OS_TEAMSPACE_PROFILE_IMAGE_URL));
 			dbTeamspace.changeProfileImageUrl(new TeamspaceProfileImageUrl(DB_TEAMSPACE_PROFILE_IMAGE_URL));
 
@@ -83,7 +85,7 @@ class UserControllerTest extends ControllerTest {
 			);
 			UserStatusResponse userStatusResponse = UserStatusResponse.of(profile, participatedTeamspaceDto);
 
-			given(userservice.getUserStatus(any(CustomUserDetails.class))).willReturn(userStatusResponse);
+			given(userService.getUserStatus(any(CustomUserDetails.class))).willReturn(userStatusResponse);
 
 			doTest(
 				ApiResponse.createSuccessResponse(userStatusResponse),
@@ -152,7 +154,7 @@ class UserControllerTest extends ControllerTest {
 		@DisplayName("마지막으로 본 팀스페이스 Id를 업데이트 할 수 있다.")
 		@WithMockCustomUser
 		void updateLastSeenTeamspace_Success() throws Exception {
-			willDoNothing().given(userservice).updateLastSeenTeamspace(any(CustomUserDetails.class), eq(request));
+			willDoNothing().given(userService).updateLastSeenTeamspace(any(CustomUserDetails.class), eq(request));
 			doTest(
 				ApiResponse.createSuccessResponse(Map.of()),
 				status().isOk(),
@@ -166,7 +168,7 @@ class UserControllerTest extends ControllerTest {
 		@DisplayName("참여하지 않은 팀스페이스 Id로 업데이트 할 수 없다.")
 		@WithMockCustomUser
 		void updateLastSeenTeamspace_Fail() throws Exception {
-			willThrow(new CommonException(ExceptionCode.FORBIDDEN_TEAMSPACE)).given(userservice)
+			willThrow(new CommonException(ExceptionCode.FORBIDDEN_TEAMSPACE)).given(userService)
 				.updateLastSeenTeamspace(any(CustomUserDetails.class), eq(request));
 
 			doTest(
@@ -204,4 +206,64 @@ class UserControllerTest extends ControllerTest {
 
 	}
 
+	@Nested
+	@DisplayName("사용자 설정 수정 문서화")
+	class UpdateUserSettingsDocs {
+		final String USER_PROFILE_IMAGE_URL = "http://user-profile-image.com";
+		final String USER_USERNAME = "홍길동";
+		final Boolean USER_EMAIL_SUBSCRIPTION = false;
+		final CommentNotification USER_COMMENTNOTIFICATION = CommentNotification.MENTION;
+
+		UpdateUserSettingRequest request = new UpdateUserSettingRequest(USER_PROFILE_IMAGE_URL, USER_USERNAME,
+			USER_EMAIL_SUBSCRIPTION, USER_COMMENTNOTIFICATION);
+
+		@Test
+		@WithMockCustomUser
+		@DisplayName("사용자 설정 수정 - 성공")
+		void updateUserSettings_success() throws Exception {
+			willDoNothing()
+				.given(userService).updateSettings(any(CustomUserDetails.class), any(UpdateUserSettingRequest.class));
+
+			doTest(
+				ApiResponse.createSuccessResponse(Map.of()),
+				status().isOk(),
+				apiDocHelper.createSuccessResponseFields(),
+				"ApiResponse"
+			);
+		}
+
+		private void doTest(
+			ApiResponse<?> response,
+			ResultMatcher statusMatcher,
+			FieldDescriptor[] responseFields,
+			String responseSchemaTitle
+		) throws Exception {
+			mockMvc.perform(patch("/api/v1/users/settings")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content(objectMapper.writeValueAsString(request))
+					.with(csrf()))
+				.andExpect(statusMatcher)
+				.andExpect(content().json(objectMapper.writeValueAsString(response)))
+				.andDo(restDocs.document(
+					resource(ResourceSnippetParameters.builder()
+						.tag("user-controller")
+						.description("사용자 자신의 설정을 수정합니다.")
+						.requestFields(
+							fieldWithPath("profileImageUrl").description("변경할 사용자 프로필 이미지 Url(선택)")
+								.type(JsonFieldType.STRING),
+							fieldWithPath("username").description("변경할 사용자 이름(선택)")
+								.type(JsonFieldType.STRING),
+							fieldWithPath("emailSubscription").description("변경할 사용자 팀스페이스 활동 메일 수신 여부(선택)")
+								.type(JsonFieldType.BOOLEAN),
+							fieldWithPath("commentNotification").description(
+									"변경할 사용자 댓글 알림 수신 범위 지정(선택) ('ALL', 'MENTION')")
+								.type(JsonFieldType.STRING)
+						)
+						.responseFields(responseFields)
+						.responseSchema(Schema.schema(responseSchemaTitle))
+						.build()
+					)))
+				.andDo(print());
+		}
+	}
 }

--- a/src/test/java/one/colla/user/presentation/UserControllerTest.java
+++ b/src/test/java/one/colla/user/presentation/UserControllerTest.java
@@ -266,4 +266,46 @@ class UserControllerTest extends ControllerTest {
 				.andDo(print());
 		}
 	}
+
+	@Nested
+	@DisplayName("사용자 프로필 사진 삭제 문서화")
+	class DeleteUserProfileImageUrlDocs {
+		@Test
+		@WithMockCustomUser
+		@DisplayName("사용자 설정 수정 - 성공")
+		void deleteUserProfileImageUrl_success() throws Exception {
+			willDoNothing()
+				.given(userService)
+				.deleteProfileImageUrl(any(CustomUserDetails.class));
+
+			doTest(
+				ApiResponse.createSuccessResponse(Map.of()),
+				status().isOk(),
+				apiDocHelper.createSuccessResponseFields(),
+				"ApiResponse"
+			);
+		}
+
+		private void doTest(
+			ApiResponse<?> response,
+			ResultMatcher statusMatcher,
+			FieldDescriptor[] responseFields,
+			String responseSchemaTitle
+		) throws Exception {
+			mockMvc.perform(delete("/api/v1/users/settings/profile-image")
+					.contentType(MediaType.APPLICATION_JSON)
+					.with(csrf()))
+				.andExpect(statusMatcher)
+				.andExpect(content().json(objectMapper.writeValueAsString(response)))
+				.andDo(restDocs.document(
+					resource(ResourceSnippetParameters.builder()
+						.tag("user-controller")
+						.description("사용자 자신의 프로필 사진을 삭제합니다.")
+						.responseFields(responseFields)
+						.responseSchema(Schema.schema(responseSchemaTitle))
+						.build()
+					)))
+				.andDo(print());
+		}
+	}
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closed: https://github.com/98OO/colla-backend/issues/50

## ✨ PR 세부 내용

**1️⃣ local 환경에서도 prod 환경의 인자를 불러오는 문제 해결**  
- profiles.default를 중복으로 잘못 정의해서 발생한 문제 해결  
<br/>

**2️⃣ dto 의 필드 타입과 다른 데이터가 들어오는 경우, Json 형식이 아닌 경우에 대한 에러 핸들링**
``` java
if (ex.getCause() instanceof MismatchedInputException mismatchedInputException) {
    for (JsonMappingException.Reference reference : mismatchedInputException.getPath()) {
        errors.put(reference.getFieldName(), "필드의 값이 잘못되었습니다. Type 을 확인하세요.");
    }
} else {
    errors.put("common", "확인할 수 없는 형태의 데이터가 들어왔습니다. JSON 형식인지 확인하세요.");
    log.error("HttpMessageNotReadable 에러 발생: {}", ex.getMessage(), ex);
}

```
- Integer, Boolean, Enum 등에 대해 요청 필드의 타입이 다르게 들어오는 경우, 적절한 Validation 예외 응답을 처리할 수 있도록 ExceptionHandler 추가. 
<br/>

**3️⃣ 사용자 설정 수정, 사용자 프로필 이미지 삭제, 팀스페이스 프로필 이미지 삭제 API 구현**
<br/>


## ✅ 리뷰 요구사항
- Json 형식이 아닌 경우에 대한 에러 핸들링과 관련해서 이견 있으면 말해주세요!
