### PR TITLE
AWS CloudFront를 사용한 첨부파일 및 사진 저장 S3 버킷 CDN 설정

### DIFF
--- a/src/main/java/one/colla/common/application/dto/request/DomainType.java
+++ b/src/main/java/one/colla/common/application/dto/request/DomainType.java
@@ -1,6 +1,0 @@
-package one.colla.common.application.dto.request;
-
-public enum DomainType {
-	USER,
-	TEAMSPACE
-}

--- a/src/main/java/one/colla/common/domain/vo/Url.java
+++ b/src/main/java/one/colla/common/domain/vo/Url.java
@@ -12,6 +12,9 @@ public abstract class Url {
 			+ "(?:[-a-zA-Z0-9()@:%_\\+.~#?&\\/=]*)$";
 
 	protected void validate(final String value) {
+		if (value == null) {
+			throw new VoException("url은 null일 수 없습니다.");
+		}
 		if (value.isBlank()) {
 			throw new VoException("url은 공백일 수 없습니다.");
 		}

--- a/src/main/java/one/colla/file/domain/Attachment.java
+++ b/src/main/java/one/colla/file/domain/Attachment.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -20,6 +21,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import one.colla.chat.domain.ChatChannelMessageAttachment;
 import one.colla.common.domain.BaseEntity;
+import one.colla.file.domain.vo.FileUrl;
 import one.colla.teamspace.domain.Teamspace;
 import one.colla.user.domain.User;
 
@@ -51,8 +53,8 @@ public class Attachment extends BaseEntity {
 	@Column(name = "attach_type", nullable = false)
 	private String attachType;
 
-	@Column(name = "file_url", nullable = false)
-	private String fileUrl;
+	@Embedded
+	private FileUrl fileUrl;
 
 	@OneToMany(mappedBy = "attachment", fetch = FetchType.LAZY)
 	private final List<ChatChannelMessageAttachment> chatChannelMessageAttachments = new ArrayList<>();

--- a/src/main/java/one/colla/file/domain/vo/FileUrl.java
+++ b/src/main/java/one/colla/file/domain/vo/FileUrl.java
@@ -1,0 +1,49 @@
+package one.colla.file.domain.vo;
+
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import one.colla.common.domain.vo.Url;
+import one.colla.global.exception.VoException;
+
+@Embeddable
+@EqualsAndHashCode(callSuper = false)
+@Getter
+public class FileUrl extends Url {
+	private static final List<String> ALLOWED_URL_PREFIXES = List.of(
+		"https://cdn.colla.so/"
+	);
+
+	@Column(name = "file_url", nullable = false)
+	private String value;
+
+	public FileUrl() {
+		this.value = null;
+	}
+
+	public FileUrl(final String value) {
+		validate(value);
+		this.value = value;
+	}
+
+	public static FileUrl from(final String url) {
+		return new FileUrl(url);
+	}
+
+	public FileUrl change(final String newUrl) {
+		return new FileUrl(newUrl);
+	}
+
+	@Override
+	protected void validate(final String url) {
+		super.validate(url);
+
+		boolean isValid = ALLOWED_URL_PREFIXES.stream().anyMatch(url::startsWith);
+		if (!isValid) {
+			throw new VoException("CDN Url 이 아닙니다.");
+		}
+	}
+}

--- a/src/main/java/one/colla/infra/s3/application/FileService.java
+++ b/src/main/java/one/colla/infra/s3/application/FileService.java
@@ -1,4 +1,4 @@
-package one.colla.common.application;
+package one.colla.infra.s3.application;
 
 import java.net.URL;
 import java.util.Date;
@@ -15,13 +15,13 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
 
 import lombok.RequiredArgsConstructor;
-import one.colla.common.application.dto.request.DomainType;
-import one.colla.common.application.dto.request.FileUploadDto;
-import one.colla.common.application.dto.request.PreSignedUrlRequest;
-import one.colla.common.application.dto.response.FileUploadUrlsDto;
-import one.colla.common.application.dto.response.PreSignedUrlResponse;
 import one.colla.common.security.authentication.CustomUserDetails;
-import one.colla.common.util.S3Util;
+import one.colla.infra.s3.application.dto.request.DomainType;
+import one.colla.infra.s3.application.dto.request.FileUploadDto;
+import one.colla.infra.s3.application.dto.request.PreSignedUrlRequest;
+import one.colla.infra.s3.application.dto.response.FileUploadUrlsDto;
+import one.colla.infra.s3.application.dto.response.PreSignedUrlResponse;
+import one.colla.infra.s3.util.S3Util;
 import one.colla.teamspace.application.TeamspaceService;
 
 @Service

--- a/src/main/java/one/colla/infra/s3/application/dto/request/DomainType.java
+++ b/src/main/java/one/colla/infra/s3/application/dto/request/DomainType.java
@@ -1,0 +1,6 @@
+package one.colla.infra.s3.application.dto.request;
+
+public enum DomainType {
+	USER,
+	TEAMSPACE
+}

--- a/src/main/java/one/colla/infra/s3/application/dto/request/FileUploadDto.java
+++ b/src/main/java/one/colla/infra/s3/application/dto/request/FileUploadDto.java
@@ -1,4 +1,4 @@
-package one.colla.common.application.dto.request;
+package one.colla.infra.s3.application.dto.request;
 
 import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/one/colla/infra/s3/application/dto/request/PreSignedUrlRequest.java
+++ b/src/main/java/one/colla/infra/s3/application/dto/request/PreSignedUrlRequest.java
@@ -1,4 +1,4 @@
-package one.colla.common.application.dto.request;
+package one.colla.infra.s3.application.dto.request;
 
 import java.util.List;
 

--- a/src/main/java/one/colla/infra/s3/application/dto/response/FileUploadUrlsDto.java
+++ b/src/main/java/one/colla/infra/s3/application/dto/response/FileUploadUrlsDto.java
@@ -1,4 +1,4 @@
-package one.colla.common.application.dto.response;
+package one.colla.infra.s3.application.dto.response;
 
 import java.net.URL;
 

--- a/src/main/java/one/colla/infra/s3/application/dto/response/PreSignedUrlResponse.java
+++ b/src/main/java/one/colla/infra/s3/application/dto/response/PreSignedUrlResponse.java
@@ -1,4 +1,4 @@
-package one.colla.common.application.dto.response;
+package one.colla.infra.s3.application.dto.response;
 
 import java.util.List;
 

--- a/src/main/java/one/colla/infra/s3/presentation/S3Controller.java
+++ b/src/main/java/one/colla/infra/s3/presentation/S3Controller.java
@@ -1,4 +1,4 @@
-package one.colla.common.presentation;
+package one.colla.infra.s3.presentation;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -10,10 +10,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import one.colla.common.application.FileService;
-import one.colla.common.application.dto.request.PreSignedUrlRequest;
-import one.colla.common.application.dto.response.PreSignedUrlResponse;
+import one.colla.common.presentation.ApiResponse;
 import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.infra.s3.application.FileService;
+import one.colla.infra.s3.application.dto.request.PreSignedUrlRequest;
+import one.colla.infra.s3.application.dto.response.PreSignedUrlResponse;
 
 @RestController
 @RequestMapping("/api/v1")

--- a/src/main/java/one/colla/infra/s3/util/S3Util.java
+++ b/src/main/java/one/colla/infra/s3/util/S3Util.java
@@ -1,4 +1,4 @@
-package one.colla.common.util;
+package one.colla.infra.s3.util;
 
 import java.util.UUID;
 
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
-import one.colla.common.application.dto.request.DomainType;
+import one.colla.infra.s3.application.dto.request.DomainType;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,7 +87,7 @@ cloud:
       access-key: ${AWS_ACCESS_KEY_ID}
       secret-key: ${AWS_SECRET_ACCESS_KEY}
     s3:
-      endpoint: ${AWS_END_POINT}
+      endpoint: ${AWS_S3_END_POINT}
       bucket: ${AWS_SECRET_S3_BUCKET}
     region:
       static: ${AWS_SECRET_REGION_STATIC}
@@ -181,7 +181,7 @@ cloud:
       accessKey: ${AWS_ACCESS_KEY_ID}
       secretKey: ${AWS_SECRET_ACCESS_KEY}
     s3:
-      endpoint: ${AWS_END_POINT}
+      endpoint: ${AWS_S3_END_POINT}
       bucket: ${AWS_SECRET_S3_BUCKET}
     region:
       static: ${AWS_SECRET_REGION_STATIC}

--- a/src/test/java/one/colla/file/domain/vo/FileUrlTest.java
+++ b/src/test/java/one/colla/file/domain/vo/FileUrlTest.java
@@ -1,0 +1,117 @@
+package one.colla.file.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import one.colla.global.exception.VoException;
+
+class FileUrlTest {
+
+	@Test
+	@DisplayName("두 객체의 값이 같으면 같은 객체이다.")
+	void testEqualsAndHashCode1() {
+		// given
+		String input = "https://cdn.colla.so/profile.jpg";
+
+		// when
+		FileUrl url1 = new FileUrl(input);
+		FileUrl url2 = new FileUrl(input);
+
+		// then
+		assertThat(url1).isEqualTo(url2);
+	}
+
+	@Test
+	@DisplayName("두 객체의 값이 다르면 다른 객체이다.")
+	void testEqualsAndHashCode2() {
+		// given
+		String input1 = "https://cdn.colla.so/profile.jpg";
+		String input2 = "https://cdn.colla.so/another.jpg";
+
+		// when
+		FileUrl url1 = new FileUrl(input1);
+		FileUrl url2 = new FileUrl(input2);
+
+		// then
+		assertThat(url1).isNotEqualTo(url2);
+	}
+
+	@Test
+	@DisplayName("유효한 파일 URL을 생성할 수 있다.")
+	void testValidFileUrl() {
+		// given
+		String validUrl = "https://cdn.colla.so/file.jpg";
+
+		// when
+		FileUrl fileUrl = new FileUrl(validUrl);
+
+		// then
+		assertThat(fileUrl.getValue()).isEqualTo(validUrl);
+	}
+
+	@Test
+	@DisplayName("유효하지 않은 형식의 URL이면 예외가 발생한다.")
+	void testInvalidFileUrlFormat() {
+		// given
+		String invalidUrl = "htp:/example.com";
+
+		// when/then
+		assertThatThrownBy(() -> new FileUrl(invalidUrl))
+			.isInstanceOf(VoException.class)
+			.hasMessageContaining("url 형식이 아닙니다.");
+	}
+
+	@Test
+	@DisplayName("허용되지 않은 프리픽스의 URL이면 예외가 발생한다.")
+	void testNotAllowedFileUrlPrefix() {
+		// given
+		String invalidUrl = "https://example.com/file.jpg";
+
+		// when/then
+		assertThatThrownBy(() -> new FileUrl(invalidUrl))
+			.isInstanceOf(VoException.class)
+			.hasMessageContaining("CDN Url 이 아닙니다.");
+	}
+
+	@Test
+	@DisplayName("URL은 공백일 수 없다.")
+	void testBlankFileUrl() {
+		// given
+		String blankUrl = "   ";
+
+		// when/then
+		assertThatThrownBy(() -> new FileUrl(blankUrl))
+			.isInstanceOf(VoException.class)
+			.hasMessageContaining("url은 공백일 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("파일 URL을 변경할 수 있다.")
+	void testFileUrlChange() {
+		// given
+		String initialUrl = "https://cdn.colla.so/old_file.jpg";
+		String newUrl = "https://cdn.colla.so/new_file.jpg";
+		FileUrl fileUrl = new FileUrl(initialUrl);
+
+		// when
+		FileUrl updatedFileUrl = fileUrl.change(newUrl);
+
+		// then
+		assertThat(updatedFileUrl.getValue()).isNotEqualTo(initialUrl);
+		assertThat(updatedFileUrl.getValue()).isEqualTo(newUrl);
+	}
+
+	@Test
+	@DisplayName("URL이 null이면 예외가 발생한다.")
+	void testNullFileUrl() {
+		// given
+		String nullUrl = null;
+
+		// when/then
+		assertThatThrownBy(() -> new FileUrl(nullUrl))
+			.isInstanceOf(VoException.class)
+			.hasMessageContaining("url은 null일 수 없습니다.");
+	}
+}

--- a/src/test/java/one/colla/infra/s3/application/FileServiceTest.java
+++ b/src/test/java/one/colla/infra/s3/application/FileServiceTest.java
@@ -1,4 +1,4 @@
-package one.colla.common.application;
+package one.colla.infra.s3.application;
 
 import static one.colla.common.fixtures.TeamspaceFixtures.*;
 import static one.colla.common.fixtures.UserFixtures.*;
@@ -22,14 +22,14 @@ import org.springframework.beans.factory.annotation.Value;
 import com.amazonaws.services.s3.AmazonS3;
 
 import one.colla.common.ServiceTest;
-import one.colla.common.application.dto.request.DomainType;
-import one.colla.common.application.dto.request.FileUploadDto;
-import one.colla.common.application.dto.request.PreSignedUrlRequest;
-import one.colla.common.application.dto.response.PreSignedUrlResponse;
 import one.colla.common.security.authentication.CustomUserDetails;
-import one.colla.common.util.S3Util;
 import one.colla.global.exception.CommonException;
 import one.colla.global.exception.ExceptionCode;
+import one.colla.infra.s3.application.dto.request.DomainType;
+import one.colla.infra.s3.application.dto.request.FileUploadDto;
+import one.colla.infra.s3.application.dto.request.PreSignedUrlRequest;
+import one.colla.infra.s3.application.dto.response.PreSignedUrlResponse;
+import one.colla.infra.s3.util.S3Util;
 import one.colla.teamspace.application.TeamspaceService;
 import one.colla.teamspace.domain.Teamspace;
 import one.colla.teamspace.domain.UserTeamspace;

--- a/src/test/java/one/colla/infra/s3/application/dto/request/FileUploadDtoTest.java
+++ b/src/test/java/one/colla/infra/s3/application/dto/request/FileUploadDtoTest.java
@@ -1,4 +1,4 @@
-package one.colla.common.application.dto.request;
+package one.colla.infra.s3.application.dto.request;
 
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/one/colla/infra/s3/presentation/S3ControllerTest.java
+++ b/src/test/java/one/colla/infra/s3/presentation/S3ControllerTest.java
@@ -1,4 +1,4 @@
-package one.colla.common.presentation;
+package one.colla.infra.s3.presentation;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static one.colla.common.fixtures.UserFixtures.*;
@@ -27,16 +27,17 @@ import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 
 import one.colla.common.ControllerTest;
-import one.colla.common.application.FileService;
-import one.colla.common.application.dto.request.DomainType;
-import one.colla.common.application.dto.request.FileUploadDto;
-import one.colla.common.application.dto.request.PreSignedUrlRequest;
-import one.colla.common.application.dto.response.FileUploadUrlsDto;
-import one.colla.common.application.dto.response.PreSignedUrlResponse;
+import one.colla.common.presentation.ApiResponse;
 import one.colla.common.security.authentication.CustomUserDetails;
 import one.colla.common.security.authentication.WithMockCustomUser;
 import one.colla.global.exception.CommonException;
 import one.colla.global.exception.ExceptionCode;
+import one.colla.infra.s3.application.FileService;
+import one.colla.infra.s3.application.dto.request.DomainType;
+import one.colla.infra.s3.application.dto.request.FileUploadDto;
+import one.colla.infra.s3.application.dto.request.PreSignedUrlRequest;
+import one.colla.infra.s3.application.dto.response.FileUploadUrlsDto;
+import one.colla.infra.s3.application.dto.response.PreSignedUrlResponse;
 
 @WebMvcTest(S3Controller.class)
 class S3ControllerTest extends ControllerTest {

--- a/src/test/java/one/colla/infra/s3/util/S3UtilTest.java
+++ b/src/test/java/one/colla/infra/s3/util/S3UtilTest.java
@@ -1,4 +1,4 @@
-package one.colla.common.util;
+package one.colla.infra.s3.util;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.params.provider.Arguments.*;
@@ -15,7 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
 import one.colla.common.CommonTest;
-import one.colla.common.application.dto.request.DomainType;
+import one.colla.infra.s3.application.dto.request.DomainType;
 
 class S3UtilTest extends CommonTest {
 


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-backend/issues/57

## ✨ PR 세부 내용

**1️⃣  attachmentUrl을 기존 Origin S3 URL을 보내는 것에서 우리 서비스 CDN URL을 보내도록 변경**
- S3 원본 URL -> CDN URl(cdn.colla.so)

**2️⃣  attachments의 file_url에 우리 서비스 CDN 경로만 등록될 수 있도록 vo 작성**  

```java
public class FileUrl extends Url {
	private static final List<String> ALLOWED_URL_PREFIXES = List.of(
		"https://cdn.colla.so/"
	);
        ...
}
```
- 비정상적인 사용자의 외부 URL 등록 시도를 방지하는 조치
- `ALLOWED_URL_PREFIXES`에 허용 URL을 추가 가능 
- URL 추상 vo에 null 검증 추가


## ✅ 리뷰 요구사항
s3 로직 관련해서 리펙토링 한 부분 확인해주세요.
