### PR TITLE
피드 관련 설계 및 공통 API 개발

### DIFF
--- a/src/main/java/one/colla/feed/common/application/CommentService.java
+++ b/src/main/java/one/colla/feed/common/application/CommentService.java
@@ -1,0 +1,52 @@
+package one.colla.feed.common.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.feed.common.application.dto.request.CreateCommentRequest;
+import one.colla.feed.common.domain.Comment;
+import one.colla.feed.common.domain.CommentRepository;
+import one.colla.feed.common.domain.Feed;
+import one.colla.feed.common.domain.FeedRepository;
+import one.colla.global.exception.CommonException;
+import one.colla.global.exception.ExceptionCode;
+import one.colla.teamspace.application.TeamspaceService;
+import one.colla.teamspace.domain.Teamspace;
+import one.colla.teamspace.domain.UserTeamspace;
+import one.colla.user.domain.User;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+	private final TeamspaceService teamspaceService;
+	private final FeedRepository feedRepository;
+	private final CommentRepository commentRepository;
+
+	@Transactional
+	public void create(
+		final CustomUserDetails userDetails,
+		final Long teamspaceId,
+		final Long feedId,
+		final CreateCommentRequest request
+	) {
+		UserTeamspace userTeamspace = teamspaceService.getUserTeamspace(userDetails, teamspaceId);
+		Teamspace teamspace = userTeamspace.getTeamspace();
+		User user = userTeamspace.getUser();
+
+		Feed feed = feedRepository.findByIdAndTeamspace(feedId, teamspace)
+			.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_FEED));
+
+		Comment newComment = Comment.of(user, feed, request.content());
+		feed.addComment(newComment);
+		commentRepository.save(newComment);
+
+		log.info(
+			"댓글 작성 - 팀스페이스 Id: {}, 사용자 Id: {}, 피드 Id: {}, 생성된 댓글 Id: {}",
+			teamspaceId, user.getId(), feedId, newComment.getId()
+		);
+	}
+}

--- a/src/main/java/one/colla/feed/common/application/CommentService.java
+++ b/src/main/java/one/colla/feed/common/application/CommentService.java
@@ -49,4 +49,31 @@ public class CommentService {
 			teamspaceId, user.getId(), feedId, newComment.getId()
 		);
 	}
+
+	@Transactional
+	public void update(
+		final CustomUserDetails userDetails,
+		final Long teamspaceId,
+		final Long feedId,
+		final Long commentId,
+		final CreateCommentRequest request
+	) {
+		UserTeamspace userTeamspace = teamspaceService.getUserTeamspace(userDetails, teamspaceId);
+		Teamspace teamspace = userTeamspace.getTeamspace();
+		User user = userTeamspace.getUser();
+
+		Feed feed = feedRepository.findByIdAndTeamspace(feedId, teamspace)
+			.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_FEED));
+
+		Comment comment = commentRepository.findByIdAndUserAndFeed(commentId, user, feed)
+			.orElseThrow(() -> new CommonException(ExceptionCode.FORBIDDEN_ACCESS_COMMENT));
+
+		comment.updateContent(request.content());
+		commentRepository.save(comment);
+
+		log.info(
+			"댓글 수정 - 팀스페이스 Id: {}, 사용자 Id: {}, 피드 Id: {}, 수정된 댓글 Id: {}",
+			teamspaceId, user.getId(), feedId, comment.getId()
+		);
+	}
 }

--- a/src/main/java/one/colla/feed/common/application/FeedService.java
+++ b/src/main/java/one/colla/feed/common/application/FeedService.java
@@ -1,0 +1,131 @@
+package one.colla.feed.common.application;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.feed.common.application.dto.response.CommentDto;
+import one.colla.feed.common.application.dto.response.CommonReadFeedListResponse;
+import one.colla.feed.common.application.dto.response.CommonReadFeedResponse;
+import one.colla.feed.common.application.dto.response.ReadFeedDetails;
+import one.colla.feed.common.domain.Feed;
+import one.colla.feed.common.domain.FeedRepository;
+import one.colla.feed.common.domain.FeedType;
+import one.colla.feed.common.factory.ReadFeedDetailsFactory;
+import one.colla.feed.common.factory.ReadFeedDetailsFactoryProvider;
+import one.colla.file.domain.AttachmentType;
+import one.colla.global.exception.CommonException;
+import one.colla.global.exception.ExceptionCode;
+import one.colla.teamspace.application.TeamspaceService;
+import one.colla.teamspace.domain.Teamspace;
+import one.colla.teamspace.domain.UserTeamspace;
+import one.colla.teamspace.domain.UserTeamspaceRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FeedService {
+	private final TeamspaceService teamspaceService;
+	private final UserTeamspaceRepository userTeamspaceRepository;
+	private final FeedRepository feedRepository;
+	private final ReadFeedDetailsFactoryProvider readFeedDetailsFactoryProvider;
+
+	@Transactional(readOnly = true)
+	public CommonReadFeedListResponse readFeeds(
+		final CustomUserDetails userDetails,
+		final Long teamspaceId,
+		@Nullable final Long afterFeedId,
+		@Nullable final FeedType feedType,
+		final int limit
+	) {
+		UserTeamspace userTeamspace = teamspaceService.getUserTeamspace(userDetails, teamspaceId);
+		PageRequest pageRequest = PageRequest.of(0, limit);
+
+		if (afterFeedId != null && !feedRepository.existsById(afterFeedId)) {
+			throw new CommonException(ExceptionCode.NOT_FOUND_FEED);
+		}
+
+		List<Feed> feeds = feedRepository.findFeedsByTeamspaceAndCriteria(
+			userTeamspace.getTeamspace(),
+			afterFeedId,
+			feedType != null ? feedType.getFeedClass() : null,
+			pageRequest
+		);
+
+		List<CommonReadFeedResponse<ReadFeedDetails>> feedResponses = feeds.stream()
+			.map(this::toCommonReadFeedResponse)
+			.toList();
+
+		return CommonReadFeedListResponse.from(feedResponses);
+	}
+
+	@Transactional(readOnly = true)
+	public CommonReadFeedResponse<ReadFeedDetails> readFeed(
+		final CustomUserDetails userDetails,
+		final Long teamspaceId,
+		final Long feedId
+	) {
+		UserTeamspace userTeamspace = teamspaceService.getUserTeamspace(userDetails, teamspaceId);
+		Teamspace teamspace = userTeamspace.getTeamspace();
+
+		Feed feed = feedRepository.findByIdAndTeamspace(feedId, teamspace)
+			.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_FEED));
+
+		return toCommonReadFeedResponse(feed);
+	}
+
+	private CommonReadFeedResponse<ReadFeedDetails> toCommonReadFeedResponse(Feed feed) {
+		UserTeamspace userTeamspace = userTeamspaceRepository.findByUserIdAndTeamspaceId(
+			feed.getUser().getId(), feed.getTeamspace().getId()
+		).orElseThrow(() -> new IllegalArgumentException("탈퇴한 회원입니다."));
+
+		CommonReadFeedResponse.TagDto tagDto
+			= CommonReadFeedResponse.TagDto.from(userTeamspace.getTag());
+
+		CommonReadFeedResponse.FeedAuthorDto feedAuthorDto
+			= CommonReadFeedResponse.FeedAuthorDto.of(feed.getUser(), tagDto);
+
+		Map<AttachmentType, List<CommonReadFeedResponse.FileDto>> groupedAttachments = groupAttachmentsByType(feed);
+
+		Pair<FeedType, ReadFeedDetails> details = createReadFeedDetails(feed);
+
+		List<CommentDto> commentDtos = feed.getComments().stream().map(CommentDto::from).toList();
+
+		return CommonReadFeedResponse.of(
+			details.getLeft(),
+			feed,
+			feedAuthorDto,
+			details.getRight(),
+			commentDtos,
+			groupedAttachments.getOrDefault(AttachmentType.IMAGE, List.of()),
+			groupedAttachments.getOrDefault(AttachmentType.FILE, List.of())
+		);
+	}
+
+	private Map<AttachmentType, List<CommonReadFeedResponse.FileDto>> groupAttachmentsByType(Feed feed) {
+		return feed.getFeedAttachments().stream()
+			.collect(
+				Collectors.groupingBy(
+					feedAttachment -> feedAttachment.getAttachment().getAttachmentType(),
+					Collectors.mapping(
+						feedAttachment -> CommonReadFeedResponse.FileDto.from(feedAttachment.getAttachment()),
+						Collectors.toList()
+					)
+				)
+			);
+	}
+
+	private Pair<FeedType, ReadFeedDetails> createReadFeedDetails(Feed feed) {
+		ReadFeedDetailsFactory factory = readFeedDetailsFactoryProvider.getFactory(feed);
+		return factory.createReadFeedDetails(feed);
+	}
+}

--- a/src/main/java/one/colla/feed/common/application/FeedService.java
+++ b/src/main/java/one/colla/feed/common/application/FeedService.java
@@ -65,6 +65,10 @@ public class FeedService {
 			.map(this::toCommonReadFeedResponse)
 			.toList();
 
+		log.info(
+			"피드 목록 조회 - 팀스페이스 Id: {}, 사용자 Id: {}, afterFeedId: {}, feedType: {}, limit: {}",
+			teamspaceId, userDetails.getUserId(), afterFeedId, feedType, limit);
+
 		return CommonReadFeedListResponse.from(feedResponses);
 	}
 
@@ -80,6 +84,10 @@ public class FeedService {
 		Feed feed = feedRepository.findByIdAndTeamspace(feedId, teamspace)
 			.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_FEED));
 
+		log.info(
+			"피드 단건 조회 - 팀스페이스 Id: {}, 사용자 Id: {}, 조회 피드 Id: {}",
+			teamspaceId, userDetails.getUserId(), feedId
+		);
 		return toCommonReadFeedResponse(feed);
 	}
 
@@ -87,6 +95,7 @@ public class FeedService {
 		UserTeamspace userTeamspace = userTeamspaceRepository.findByUserIdAndTeamspaceId(
 			feed.getUser().getId(), feed.getTeamspace().getId()
 		).orElseThrow(() -> new IllegalArgumentException("탈퇴한 회원입니다."));
+		// TODO: 추후 탈퇴 회원에 대한 처리 필요
 
 		CommonReadFeedResponse.TagDto tagDto
 			= CommonReadFeedResponse.TagDto.from(userTeamspace.getTag());

--- a/src/main/java/one/colla/feed/common/application/FeedService.java
+++ b/src/main/java/one/colla/feed/common/application/FeedService.java
@@ -48,9 +48,10 @@ public class FeedService {
 		final int limit
 	) {
 		UserTeamspace userTeamspace = teamspaceService.getUserTeamspace(userDetails, teamspaceId);
+		Teamspace teamspace = userTeamspace.getTeamspace();
 		PageRequest pageRequest = PageRequest.of(0, limit);
 
-		if (afterFeedId != null && !feedRepository.existsById(afterFeedId)) {
+		if (afterFeedId != null && !feedRepository.existByIdAndTeamspace(afterFeedId, teamspace)) {
 			throw new CommonException(ExceptionCode.NOT_FOUND_FEED);
 		}
 
@@ -67,7 +68,8 @@ public class FeedService {
 
 		log.info(
 			"피드 목록 조회 - 팀스페이스 Id: {}, 사용자 Id: {}, afterFeedId: {}, feedType: {}, limit: {}",
-			teamspaceId, userDetails.getUserId(), afterFeedId, feedType, limit);
+			teamspaceId, userDetails.getUserId(), afterFeedId, feedType, limit
+		);
 
 		return CommonReadFeedListResponse.from(feedResponses);
 	}

--- a/src/main/java/one/colla/feed/common/application/FeedService.java
+++ b/src/main/java/one/colla/feed/common/application/FeedService.java
@@ -51,7 +51,7 @@ public class FeedService {
 		Teamspace teamspace = userTeamspace.getTeamspace();
 		PageRequest pageRequest = PageRequest.of(0, limit);
 
-		if (afterFeedId != null && !feedRepository.existByIdAndTeamspace(afterFeedId, teamspace)) {
+		if (afterFeedId != null && !feedRepository.existsByIdAndTeamspace(afterFeedId, teamspace)) {
 			throw new CommonException(ExceptionCode.NOT_FOUND_FEED);
 		}
 

--- a/src/main/java/one/colla/feed/common/application/dto/request/CommonCreateFeedRequest.java
+++ b/src/main/java/one/colla/feed/common/application/dto/request/CommonCreateFeedRequest.java
@@ -1,0 +1,42 @@
+package one.colla.feed.common.application.dto.request;
+
+import java.util.List;
+
+import org.hibernate.validator.constraints.URL;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public record CommonCreateFeedRequest<T extends CreateFeedDetails>(
+	@NotBlank(message = "제목을 포함해주세요.")
+	@Size(max = 50, message = "제목은 50자 이하여야 합니다")
+	String title,
+
+	@Valid
+	List<FileDto> images,
+
+	@Valid
+	List<FileDto> attachments,
+
+	@Valid
+	T details
+) {
+	public record FileDto(
+		@NotBlank(message = "파일명을 포함해주세요.")
+		@Size(max = 255, message = "파일명은 255자 이하여야 합니다.")
+		String name,
+
+		@NotBlank(message = "파일 경로를 포함해주세요.")
+		@URL(message = "URL 형식이 아닙니다.")
+		@Size(max = 2048, message = "파일 경로는 2048 이하여야 합니다.")
+		String fileUrl,
+
+		@NotNull(message = "파일 크기를 포함해주세요.")
+		@Positive(message = "파일 크기는 양수여야 합니다.")
+		Long size
+	) {
+	}
+}

--- a/src/main/java/one/colla/feed/common/application/dto/request/CreateCommentRequest.java
+++ b/src/main/java/one/colla/feed/common/application/dto/request/CreateCommentRequest.java
@@ -1,0 +1,11 @@
+package one.colla.feed.common.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateCommentRequest(
+	@NotBlank(message = "댓글 내용을 포함해주세요.")
+	@Size(max = 250, message = "댓글 내용은 250자 이하여야 합니다")
+	String content
+) {
+}

--- a/src/main/java/one/colla/feed/common/application/dto/request/CreateFeedDetails.java
+++ b/src/main/java/one/colla/feed/common/application/dto/request/CreateFeedDetails.java
@@ -1,0 +1,4 @@
+package one.colla.feed.common.application.dto.request;
+
+public interface CreateFeedDetails {
+}

--- a/src/main/java/one/colla/feed/common/application/dto/response/CommentDto.java
+++ b/src/main/java/one/colla/feed/common/application/dto/response/CommentDto.java
@@ -23,7 +23,7 @@ public record CommentDto(
 		return new CommentDto(commentAuthorDto, comment.getContent(), comment.getCreatedAt());
 	}
 
-	private record CommentAuthorDto(
+	public record CommentAuthorDto(
 		Long id,
 		String profileImageUrl,
 		String username

--- a/src/main/java/one/colla/feed/common/application/dto/response/CommentDto.java
+++ b/src/main/java/one/colla/feed/common/application/dto/response/CommentDto.java
@@ -3,6 +3,8 @@ package one.colla.feed.common.application.dto.response;
 import java.time.LocalDateTime;
 
 import lombok.Builder;
+import one.colla.feed.common.domain.Comment;
+import one.colla.user.domain.User;
 
 @Builder
 public record CommentDto(
@@ -10,11 +12,22 @@ public record CommentDto(
 	String content,
 	LocalDateTime createdAt
 ) {
+	public static CommentDto from(Comment comment) {
+		CommentAuthorDto commentAuthorDto = CommentAuthorDto.from(comment.getUser());
+		return new CommentDto(commentAuthorDto, comment.getContent(), comment.getCreatedAt());
+	}
 
-	public record CommentAuthorDto(
+	private record CommentAuthorDto(
 		Long id,
 		String profileImageUrl,
 		String username
 	) {
+		public static CommentAuthorDto from(User user) {
+			return new CommentAuthorDto(
+				user.getId(),
+				user.getProfileImageUrlValue(),
+				user.getUsernameValue()
+			);
+		}
 	}
 }

--- a/src/main/java/one/colla/feed/common/application/dto/response/CommentDto.java
+++ b/src/main/java/one/colla/feed/common/application/dto/response/CommentDto.java
@@ -1,0 +1,20 @@
+package one.colla.feed.common.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+
+@Builder
+public record CommentDto(
+	CommentAuthorDto author,
+	String content,
+	LocalDateTime createdAt
+) {
+
+	public record CommentAuthorDto(
+		Long id,
+		String profileImageUrl,
+		String username
+	) {
+	}
+}

--- a/src/main/java/one/colla/feed/common/application/dto/response/CommentDto.java
+++ b/src/main/java/one/colla/feed/common/application/dto/response/CommentDto.java
@@ -2,6 +2,10 @@ package one.colla.feed.common.application.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
 import lombok.Builder;
 import one.colla.feed.common.domain.Comment;
 import one.colla.user.domain.User;
@@ -10,6 +14,8 @@ import one.colla.user.domain.User;
 public record CommentDto(
 	CommentAuthorDto author,
 	String content,
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
 	LocalDateTime createdAt
 ) {
 	public static CommentDto from(Comment comment) {

--- a/src/main/java/one/colla/feed/common/application/dto/response/CommonReadFeedListResponse.java
+++ b/src/main/java/one/colla/feed/common/application/dto/response/CommonReadFeedListResponse.java
@@ -3,6 +3,11 @@ package one.colla.feed.common.application.dto.response;
 import java.util.List;
 
 public record CommonReadFeedListResponse(
-	List<CommonReadFeedResponse<ReadFeedDetails>> commonReadFeedResponses
+	List<CommonReadFeedResponse<ReadFeedDetails>> feeds
 ) {
+	public static CommonReadFeedListResponse from(
+		final List<CommonReadFeedResponse<ReadFeedDetails>> commonReadFeedResponses
+	) {
+		return new CommonReadFeedListResponse(commonReadFeedResponses);
+	}
 }

--- a/src/main/java/one/colla/feed/common/application/dto/response/CommonReadFeedListResponse.java
+++ b/src/main/java/one/colla/feed/common/application/dto/response/CommonReadFeedListResponse.java
@@ -1,0 +1,8 @@
+package one.colla.feed.common.application.dto.response;
+
+import java.util.List;
+
+public record CommonReadFeedListResponse(
+	List<CommonReadFeedResponse<ReadFeedDetails>> commonReadFeedResponses
+) {
+}

--- a/src/main/java/one/colla/feed/common/application/dto/response/CommonReadFeedResponse.java
+++ b/src/main/java/one/colla/feed/common/application/dto/response/CommonReadFeedResponse.java
@@ -1,0 +1,42 @@
+package one.colla.feed.common.application.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.Builder;
+import one.colla.feed.common.domain.FeedType;
+
+@Builder
+public record CommonReadFeedResponse<T extends ReadFeedDetails>(
+	FeedType feedType,
+	Long feedId,
+	FeedAuthorDto author,
+	String title,
+	LocalDateTime createdAt,
+	T details,
+	List<CommentDto> comments,
+	List<FileDto> images,
+	List<FileDto> attachments
+) {
+	public record FeedAuthorDto(
+		Long id,
+		String profileImageUrl,
+		String username,
+		TagDto tag
+	) {
+	}
+
+	public record TagDto(
+		Long id,
+		String name
+	) {
+	}
+
+	public record FileDto(
+		Long id,
+		String name,
+		String fileUrl,
+		Long size
+	) {
+	}
+}

--- a/src/main/java/one/colla/feed/common/application/dto/response/CommonReadFeedResponse.java
+++ b/src/main/java/one/colla/feed/common/application/dto/response/CommonReadFeedResponse.java
@@ -3,8 +3,17 @@ package one.colla.feed.common.application.dto.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
+import jakarta.annotation.Nullable;
 import lombok.Builder;
+import one.colla.feed.common.domain.Feed;
 import one.colla.feed.common.domain.FeedType;
+import one.colla.file.domain.Attachment;
+import one.colla.teamspace.domain.Tag;
+import one.colla.user.domain.User;
 
 @Builder
 public record CommonReadFeedResponse<T extends ReadFeedDetails>(
@@ -12,24 +21,59 @@ public record CommonReadFeedResponse<T extends ReadFeedDetails>(
 	Long feedId,
 	FeedAuthorDto author,
 	String title,
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
 	LocalDateTime createdAt,
 	T details,
 	List<CommentDto> comments,
 	List<FileDto> images,
 	List<FileDto> attachments
 ) {
+	public static <T extends ReadFeedDetails> CommonReadFeedResponse<T> of(
+		FeedType feedType,
+		Feed feed,
+		FeedAuthorDto feedAuthorDto,
+		T details,
+		List<CommentDto> comments,
+		List<FileDto> images,
+		List<FileDto> attachments
+	) {
+		return new CommonReadFeedResponse<>(
+			feedType,
+			feed.getId(),
+			feedAuthorDto,
+			feed.getTitle(),
+			feed.getCreatedAt(),
+			details,
+			comments,
+			images,
+			attachments
+		);
+	}
+
 	public record FeedAuthorDto(
 		Long id,
 		String profileImageUrl,
 		String username,
 		TagDto tag
 	) {
+		public static FeedAuthorDto of(User user, TagDto tagDto) {
+			return new FeedAuthorDto(
+				user.getId(),
+				user.getProfileImageUrlValue(),
+				user.getUsernameValue(),
+				tagDto
+			);
+		}
 	}
 
 	public record TagDto(
 		Long id,
 		String name
 	) {
+		public static TagDto from(@Nullable Tag tag) {
+			return tag != null ? new TagDto(tag.getId(), tag.getTagNameValue()) : null;
+		}
 	}
 
 	public record FileDto(
@@ -38,5 +82,13 @@ public record CommonReadFeedResponse<T extends ReadFeedDetails>(
 		String fileUrl,
 		Long size
 	) {
+		public static FileDto from(Attachment attachment) {
+			return new FileDto(
+				attachment.getId(),
+				attachment.getAttachmentNameValue(),
+				attachment.getFileUrlValue(),
+				attachment.getSize()
+			);
+		}
 	}
 }

--- a/src/main/java/one/colla/feed/common/application/dto/response/CommonReadFeedResponse.java
+++ b/src/main/java/one/colla/feed/common/application/dto/response/CommonReadFeedResponse.java
@@ -22,7 +22,7 @@ public record CommonReadFeedResponse<T extends ReadFeedDetails>(
 	FeedAuthorDto author,
 	String title,
 	@JsonSerialize(using = LocalDateTimeSerializer.class)
-	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
 	LocalDateTime createdAt,
 	T details,
 	List<CommentDto> comments,

--- a/src/main/java/one/colla/feed/common/application/dto/response/ReadFeedDetails.java
+++ b/src/main/java/one/colla/feed/common/application/dto/response/ReadFeedDetails.java
@@ -1,0 +1,4 @@
+package one.colla.feed.common.application.dto.response;
+
+public interface ReadFeedDetails {
+}

--- a/src/main/java/one/colla/feed/common/domain/Comment.java
+++ b/src/main/java/one/colla/feed/common/domain/Comment.java
@@ -45,4 +45,8 @@ public class Comment extends BaseEntity {
 	public static Comment of(User user, Feed feed, String content) {
 		return new Comment(user, feed, content);
 	}
+
+	public void updateContent(String content) {
+		this.content = content;
+	}
 }

--- a/src/main/java/one/colla/feed/common/domain/Comment.java
+++ b/src/main/java/one/colla/feed/common/domain/Comment.java
@@ -36,4 +36,13 @@ public class Comment extends BaseEntity {
 	@Column(name = "content", nullable = false)
 	private String content;
 
+	private Comment(User user, Feed feed, String content) {
+		this.user = user;
+		this.feed = feed;
+		this.content = content;
+	}
+
+	public static Comment of(User user, Feed feed, String content) {
+		return new Comment(user, feed, content);
+	}
 }

--- a/src/main/java/one/colla/feed/common/domain/CommentRepository.java
+++ b/src/main/java/one/colla/feed/common/domain/CommentRepository.java
@@ -1,6 +1,11 @@
 package one.colla.feed.common.domain;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import one.colla.user.domain.User;
+
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+	Optional<Comment> findByIdAndUserAndFeed(Long commentId, User user, Feed feed);
 }

--- a/src/main/java/one/colla/feed/common/domain/CommentRepository.java
+++ b/src/main/java/one/colla/feed/common/domain/CommentRepository.java
@@ -8,4 +8,6 @@ import one.colla.user.domain.User;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 	Optional<Comment> findByIdAndUserAndFeed(Long commentId, User user, Feed feed);
+
+	Optional<Comment> findByIdAndFeed(Long commentId, Feed feed);
 }

--- a/src/main/java/one/colla/feed/common/domain/CommentRepository.java
+++ b/src/main/java/one/colla/feed/common/domain/CommentRepository.java
@@ -1,0 +1,6 @@
+package one.colla.feed.common.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/one/colla/feed/common/domain/Feed.java
+++ b/src/main/java/one/colla/feed/common/domain/Feed.java
@@ -117,4 +117,8 @@ public abstract class Feed extends BaseEntity {
 	public void addComment(Comment comment) {
 		this.comments.add(comment);
 	}
+
+	public void removeComment(Comment comment) {
+		this.comments.remove(comment);
+	}
 }

--- a/src/main/java/one/colla/feed/common/domain/Feed.java
+++ b/src/main/java/one/colla/feed/common/domain/Feed.java
@@ -18,6 +18,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import jakarta.persistence.OrderBy;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -56,7 +57,8 @@ public abstract class Feed extends BaseEntity {
 	@OneToOne(mappedBy = "feed", cascade = CascadeType.ALL)
 	private CalendarEventFeedLink calendarEventFeedLink;
 
-	@OneToMany(mappedBy = "feed", fetch = FetchType.LAZY)
+	@OneToMany(mappedBy = "feed", fetch = FetchType.LAZY, orphanRemoval = true)
+	@OrderBy("createdAt ASC")
 	private final List<Comment> comments = new ArrayList<>();
 
 	@OneToMany(mappedBy = "feed", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
@@ -110,5 +112,9 @@ public abstract class Feed extends BaseEntity {
 		return fileDtos.stream()
 			.map(fileDto -> Attachment.of(user, teamspace, attachmentType, fileDto))
 			.toList();
+	}
+
+	public void addComment(Comment comment) {
+		this.comments.add(comment);
 	}
 }

--- a/src/main/java/one/colla/feed/common/domain/Feed.java
+++ b/src/main/java/one/colla/feed/common/domain/Feed.java
@@ -23,6 +23,10 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import one.colla.common.domain.BaseEntity;
+import one.colla.feed.common.application.dto.request.CommonCreateFeedRequest;
+import one.colla.feed.common.application.dto.request.CreateFeedDetails;
+import one.colla.file.domain.Attachment;
+import one.colla.file.domain.AttachmentType;
 import one.colla.schedule.domain.CalendarEventFeedLink;
 import one.colla.teamspace.domain.Teamspace;
 import one.colla.user.domain.User;
@@ -34,7 +38,6 @@ import one.colla.user.domain.User;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "feeds")
 public abstract class Feed extends BaseEntity {
-
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -56,7 +59,56 @@ public abstract class Feed extends BaseEntity {
 	@OneToMany(mappedBy = "feed", fetch = FetchType.LAZY)
 	private final List<Comment> comments = new ArrayList<>();
 
-	@OneToMany(mappedBy = "feed", fetch = FetchType.LAZY)
+	@OneToMany(mappedBy = "feed", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
 	private final List<FeedAttachment> feedAttachments = new ArrayList<>();
 
+	protected Feed(
+		final User user,
+		final Teamspace teamspace,
+		final CommonCreateFeedRequest<? extends CreateFeedDetails> commonCreateFeedRequest
+	) {
+		setUser(user);
+		setTeamspace(teamspace);
+		this.title = commonCreateFeedRequest.title();
+
+		if (commonCreateFeedRequest.images() != null) {
+			List<Attachment> imageFiles =
+				createAttachments(commonCreateFeedRequest.images(), user, teamspace, AttachmentType.IMAGE);
+			addAttachments(imageFiles);
+		}
+
+		if (commonCreateFeedRequest.attachments() != null) {
+			List<Attachment> attachmentFiles =
+				createAttachments(commonCreateFeedRequest.attachments(), user, teamspace, AttachmentType.FILE);
+			addAttachments(attachmentFiles);
+		}
+	}
+
+	public void setUser(User user) {
+		this.user = user;
+		user.getFeeds().add(this);
+	}
+
+	public void setTeamspace(Teamspace teamspace) {
+		this.teamspace = teamspace;
+		teamspace.getFeeds().add(this);
+	}
+
+	private void addAttachments(List<Attachment> attachments) {
+		List<FeedAttachment> newFeedAttachments = attachments.stream()
+			.map(attachment -> FeedAttachment.of(this, attachment))
+			.toList();
+		this.feedAttachments.addAll(newFeedAttachments);
+	}
+
+	private List<Attachment> createAttachments(
+		List<CommonCreateFeedRequest.FileDto> fileDtos,
+		User user,
+		Teamspace teamspace,
+		AttachmentType attachmentType
+	) {
+		return fileDtos.stream()
+			.map(fileDto -> Attachment.of(user, teamspace, attachmentType, fileDto))
+			.toList();
+	}
 }

--- a/src/main/java/one/colla/feed/common/domain/FeedAttachment.java
+++ b/src/main/java/one/colla/feed/common/domain/FeedAttachment.java
@@ -21,7 +21,7 @@ import one.colla.file.domain.Attachment;
 public class FeedAttachment {
 
 	@EmbeddedId
-	private FeedAttachmentId feedAttachmentId;
+	private FeedAttachmentId feedAttachmentId = new FeedAttachmentId();
 
 	@MapsId("feedId")
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -32,6 +32,15 @@ public class FeedAttachment {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "attachment_id", nullable = false, updatable = false)
 	private Attachment attachment;
+
+	private FeedAttachment(Feed feed, Attachment attachment) {
+		this.feed = feed;
+		this.attachment = attachment;
+	}
+
+	public static FeedAttachment of(Feed feed, Attachment attachment) {
+		return new FeedAttachment(feed, attachment);
+	}
 
 	public static class FeedAttachmentId extends CompositeKeyBase {
 		@Column(name = "feed_id")

--- a/src/main/java/one/colla/feed/common/domain/FeedRepository.java
+++ b/src/main/java/one/colla/feed/common/domain/FeedRepository.java
@@ -12,8 +12,9 @@ import jakarta.annotation.Nullable;
 import one.colla.teamspace.domain.Teamspace;
 
 public interface FeedRepository extends JpaRepository<Feed, Long> {
-
 	Optional<Feed> findByIdAndTeamspace(Long feedId, Teamspace teamspace);
+
+	boolean existByIdAndTeamspace(Long afterFeedId, Teamspace teamspace);
 
 	/**
 	 * 주어진 팀스페이스와 기준에 따라 피드를 찾습니다.

--- a/src/main/java/one/colla/feed/common/domain/FeedRepository.java
+++ b/src/main/java/one/colla/feed/common/domain/FeedRepository.java
@@ -1,0 +1,38 @@
+package one.colla.feed.common.domain;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import jakarta.annotation.Nullable;
+import one.colla.teamspace.domain.Teamspace;
+
+public interface FeedRepository extends JpaRepository<Feed, Long> {
+
+	Optional<Feed> findByIdAndTeamspace(Long feedId, Teamspace teamspace);
+
+	/**
+	 * 주어진 팀스페이스와 기준에 따라 피드를 찾습니다.
+	 * 결과는 생성 날짜 기준 내림차순으로 정렬됩니다.
+	 *
+	 * @param teamspace 피드를 필터링할 팀스페이스
+	 * @param after 선택적 피드 ID로, 이 피드의 생성 날짜 이전에 생성된 피드들을 필터링합니다
+	 * @param feedClass 선택적 피드 클래스로, 타입별로 피드를 필터링합니다
+	 * @param pageable 페이징 정보
+	 * @return 주어진 기준에 맞는 피드 목록
+	 */
+	@Query("SELECT f FROM Feed f WHERE f.teamspace = :teamspace "
+		+ "AND (:after IS NULL OR f.createdAt < (SELECT subf.createdAt FROM Feed subf WHERE subf.id = :after)) "
+		+ "AND (:feedClass IS NULL OR TYPE(f) = :feedClass) ORDER BY f.createdAt DESC"
+	)
+	List<Feed> findFeedsByTeamspaceAndCriteria(
+		@Param("teamspace") Teamspace teamspace,
+		@Param("after") @Nullable Long after,
+		@Param("feedClass") @Nullable Class<? extends Feed> feedClass,
+		Pageable pageable
+	);
+}

--- a/src/main/java/one/colla/feed/common/domain/FeedRepository.java
+++ b/src/main/java/one/colla/feed/common/domain/FeedRepository.java
@@ -14,7 +14,7 @@ import one.colla.teamspace.domain.Teamspace;
 public interface FeedRepository extends JpaRepository<Feed, Long> {
 	Optional<Feed> findByIdAndTeamspace(Long feedId, Teamspace teamspace);
 
-	boolean existByIdAndTeamspace(Long afterFeedId, Teamspace teamspace);
+	boolean existsByIdAndTeamspace(Long afterFeedId, Teamspace teamspace);
 
 	/**
 	 * 주어진 팀스페이스와 기준에 따라 피드를 찾습니다.

--- a/src/main/java/one/colla/feed/common/domain/FeedType.java
+++ b/src/main/java/one/colla/feed/common/domain/FeedType.java
@@ -1,16 +1,25 @@
 package one.colla.feed.common.domain;
 
+import lombok.Getter;
+import one.colla.feed.collect.domain.CollectFeed;
+import one.colla.feed.normal.domain.NormalFeed;
+import one.colla.feed.scheduling.domain.SchedulingFeed;
+import one.colla.feed.vote.domain.VoteFeed;
+
 public enum FeedType {
-	NORMAL(Values.NORMAL),
-	VOTE(Values.VOTE),
-	SCHEDULING(Values.SCHEDULING),
-	COLLECT(Values.COLLECT);
+	NORMAL(Values.NORMAL, NormalFeed.class),
+	VOTE(Values.VOTE, VoteFeed.class),
+	SCHEDULING(Values.SCHEDULING, SchedulingFeed.class),
+	COLLECT(Values.COLLECT, CollectFeed.class);
 
 	private final String value;
+	@Getter
+	private final Class<? extends Feed> feedClass;
 
-	FeedType(String val) {
-		this.value = val;
-		if (!this.name().equals(val)) {
+	FeedType(String value, Class<? extends Feed> feedClass) {
+		this.value = value;
+		this.feedClass = feedClass;
+		if (!this.name().equals(value)) {
 			throw new IllegalArgumentException("Incorrect use of DType");
 		}
 	}

--- a/src/main/java/one/colla/feed/common/factory/NormalReadFeedDetailsFactory.java
+++ b/src/main/java/one/colla/feed/common/factory/NormalReadFeedDetailsFactory.java
@@ -1,0 +1,21 @@
+package one.colla.feed.common.factory;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import one.colla.feed.common.application.dto.response.ReadFeedDetails;
+import one.colla.feed.common.domain.Feed;
+import one.colla.feed.common.domain.FeedType;
+import one.colla.feed.normal.application.dto.response.ReadNormalFeedDetails;
+import one.colla.feed.normal.domain.NormalFeed;
+
+public class NormalReadFeedDetailsFactory implements ReadFeedDetailsFactory {
+	@Override
+	public Pair<FeedType, ReadFeedDetails> createReadFeedDetails(Feed feed) {
+		if (feed instanceof NormalFeed normalFeed) {
+			return Pair.of(FeedType.NORMAL, ReadNormalFeedDetails.from(normalFeed.getContent()));
+
+		} else {
+			throw new IllegalArgumentException("Unsupported feed type");
+		}
+	}
+}

--- a/src/main/java/one/colla/feed/common/factory/ReadFeedDetailsFactory.java
+++ b/src/main/java/one/colla/feed/common/factory/ReadFeedDetailsFactory.java
@@ -1,0 +1,11 @@
+package one.colla.feed.common.factory;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import one.colla.feed.common.application.dto.response.ReadFeedDetails;
+import one.colla.feed.common.domain.Feed;
+import one.colla.feed.common.domain.FeedType;
+
+public interface ReadFeedDetailsFactory {
+	Pair<FeedType, ReadFeedDetails> createReadFeedDetails(Feed feed);
+}

--- a/src/main/java/one/colla/feed/common/factory/ReadFeedDetailsFactoryProvider.java
+++ b/src/main/java/one/colla/feed/common/factory/ReadFeedDetailsFactoryProvider.java
@@ -1,0 +1,28 @@
+package one.colla.feed.common.factory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import one.colla.feed.common.domain.Feed;
+import one.colla.feed.normal.domain.NormalFeed;
+
+@Component
+public class ReadFeedDetailsFactoryProvider {
+	private final Map<Class<? extends Feed>, ReadFeedDetailsFactory> factories = new HashMap<>();
+
+	public ReadFeedDetailsFactoryProvider() {
+		factories.put(NormalFeed.class, new NormalReadFeedDetailsFactory());
+		// 다른 피드 타입의 팩토리도 여기에 추가
+	}
+
+	public ReadFeedDetailsFactory getFactory(Feed feed) {
+		ReadFeedDetailsFactory factory = factories.get(feed.getClass());
+
+		if (factory == null) {
+			throw new IllegalArgumentException("No factory for feed type: " + feed.getClass().getName());
+		}
+		return factory;
+	}
+}

--- a/src/main/java/one/colla/feed/common/presentation/CommentController.java
+++ b/src/main/java/one/colla/feed/common/presentation/CommentController.java
@@ -1,0 +1,75 @@
+package one.colla.feed.common.presentation;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import one.colla.common.presentation.ApiResponse;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.feed.common.application.CommentService;
+import one.colla.feed.common.application.dto.request.CreateCommentRequest;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/teamspaces/{teamspaceId}/feeds/{feedId}/comments")
+public class CommentController {
+	private final CommentService commentService;
+
+	@PostMapping
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Object>> createComment(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final Long teamspaceId,
+		@PathVariable final Long feedId,
+		@RequestBody @Valid final CreateCommentRequest request
+	) {
+		commentService.create(userDetails, teamspaceId, feedId, request);
+
+		return ResponseEntity.ok().body(
+			ApiResponse.createSuccessResponse(
+				Map.of()
+			)
+		);
+	}
+
+	@PatchMapping("/{commentId}")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Object>> patchComment(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final Long teamspaceId,
+		@PathVariable final Long feedId,
+		@PathVariable final Long commentId
+	) {
+
+		// TODO: 댓글 수정 구현 필요
+		return ResponseEntity.ok().body(
+			ApiResponse.createSuccessResponse(Map.of())
+		);
+	}
+
+	@DeleteMapping("/{commentId}")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Object>> deleteComment(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final Long teamspaceId,
+		@PathVariable final Long feedId,
+		@PathVariable final Long commentId
+	) {
+
+		// TODO: 댓글 삭제 구현 필요
+		return ResponseEntity.ok().body(
+			ApiResponse.createSuccessResponse(Map.of())
+		);
+	}
+}

--- a/src/main/java/one/colla/feed/common/presentation/CommentController.java
+++ b/src/main/java/one/colla/feed/common/presentation/CommentController.java
@@ -67,8 +67,8 @@ public class CommentController {
 		@PathVariable final Long feedId,
 		@PathVariable final Long commentId
 	) {
+		commentService.delete(userDetails, teamspaceId, feedId, commentId);
 
-		// TODO: 댓글 삭제 구현 필요
 		return ResponseEntity.ok().body(
 			ApiResponse.createSuccessResponse(Map.of())
 		);

--- a/src/main/java/one/colla/feed/common/presentation/CommentController.java
+++ b/src/main/java/one/colla/feed/common/presentation/CommentController.java
@@ -49,10 +49,11 @@ public class CommentController {
 		@AuthenticationPrincipal final CustomUserDetails userDetails,
 		@PathVariable final Long teamspaceId,
 		@PathVariable final Long feedId,
-		@PathVariable final Long commentId
+		@PathVariable final Long commentId,
+		@RequestBody @Valid final CreateCommentRequest request
 	) {
+		commentService.update(userDetails, teamspaceId, feedId, commentId, request);
 
-		// TODO: 댓글 수정 구현 필요
 		return ResponseEntity.ok().body(
 			ApiResponse.createSuccessResponse(Map.of())
 		);

--- a/src/main/java/one/colla/feed/common/presentation/FeedController.java
+++ b/src/main/java/one/colla/feed/common/presentation/FeedController.java
@@ -1,0 +1,58 @@
+package one.colla.feed.common.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import one.colla.common.presentation.ApiResponse;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.feed.common.application.FeedService;
+import one.colla.feed.common.application.dto.response.CommonReadFeedListResponse;
+import one.colla.feed.common.application.dto.response.CommonReadFeedResponse;
+import one.colla.feed.common.application.dto.response.ReadFeedDetails;
+import one.colla.feed.common.domain.FeedType;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/teamspaces/{teamspaceId}/feeds")
+public class FeedController {
+	private final FeedService feedService;
+
+	@GetMapping
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<CommonReadFeedListResponse>> getFeeds(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final Long teamspaceId,
+		@RequestParam(value = "after", required = false) final Long afterFeedId,
+		@RequestParam(value = "type", required = false) final FeedType feedType,
+		@RequestParam(value = "limit", defaultValue = "5") @Valid @Positive final int limit
+	) {
+		return ResponseEntity.ok().body(
+			ApiResponse.createSuccessResponse(
+				feedService.readFeeds(userDetails, teamspaceId, afterFeedId, feedType, limit)
+			)
+		);
+	}
+
+	@GetMapping("/{feedId}")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<CommonReadFeedResponse<ReadFeedDetails>>> getFeed(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final Long teamspaceId,
+		@PathVariable final Long feedId
+	) {
+		return ResponseEntity.ok().body(
+			ApiResponse.createSuccessResponse(
+				feedService.readFeed(userDetails, teamspaceId, feedId)
+			)
+		);
+	}
+}

--- a/src/main/java/one/colla/feed/normal/application/NormalFeedService.java
+++ b/src/main/java/one/colla/feed/normal/application/NormalFeedService.java
@@ -1,0 +1,43 @@
+package one.colla.feed.normal.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.feed.common.application.dto.request.CommonCreateFeedRequest;
+import one.colla.feed.normal.application.dto.request.CreateNormalFeedDetails;
+import one.colla.feed.normal.domain.NormalFeed;
+import one.colla.feed.normal.domain.NormalFeedRepository;
+import one.colla.teamspace.application.TeamspaceService;
+import one.colla.teamspace.domain.Teamspace;
+import one.colla.teamspace.domain.UserTeamspace;
+import one.colla.user.domain.User;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NormalFeedService {
+	private final TeamspaceService teamspaceService;
+	private final NormalFeedRepository normalFeedRepository;
+
+	@Transactional
+	public void create(
+		final CustomUserDetails userDetails,
+		final Long teamspaceId,
+		final CommonCreateFeedRequest<CreateNormalFeedDetails> createNormalFeedRequest
+	) {
+		UserTeamspace userTeamspace = teamspaceService.getUserTeamspace(userDetails, teamspaceId);
+		Teamspace teamspace = userTeamspace.getTeamspace();
+		User user = userTeamspace.getUser();
+
+		NormalFeed normalFeed = NormalFeed.of(user, teamspace, createNormalFeedRequest);
+		normalFeedRepository.save(normalFeed);
+
+		log.info(
+			"피드(일반) 작성 - 팀스페이스 Id: {}, 생성한 사용자 Id: {}, 피드 Id: {}",
+			teamspaceId, user.getId(), normalFeed.getId()
+		);
+	}
+}

--- a/src/main/java/one/colla/feed/normal/application/dto/request/CreateNormalFeedDetails.java
+++ b/src/main/java/one/colla/feed/normal/application/dto/request/CreateNormalFeedDetails.java
@@ -1,0 +1,8 @@
+package one.colla.feed.normal.application.dto.request;
+
+import one.colla.feed.common.application.dto.request.CreateFeedDetails;
+
+public record CreateNormalFeedDetails(
+	String content
+) implements CreateFeedDetails {
+}

--- a/src/main/java/one/colla/feed/normal/application/dto/response/ReadNormalFeedDetails.java
+++ b/src/main/java/one/colla/feed/normal/application/dto/response/ReadNormalFeedDetails.java
@@ -1,0 +1,11 @@
+package one.colla.feed.normal.application.dto.response;
+
+import one.colla.feed.common.application.dto.response.ReadFeedDetails;
+
+public record ReadNormalFeedDetails(
+	String content
+) implements ReadFeedDetails {
+	public static ReadNormalFeedDetails from(String content) {
+		return new ReadNormalFeedDetails(content);
+	}
+}

--- a/src/main/java/one/colla/feed/normal/domain/NormalFeed.java
+++ b/src/main/java/one/colla/feed/normal/domain/NormalFeed.java
@@ -4,14 +4,48 @@ import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import one.colla.feed.common.application.dto.request.CommonCreateFeedRequest;
+import one.colla.feed.common.application.dto.request.CreateFeedDetails;
 import one.colla.feed.common.domain.Feed;
+import one.colla.feed.normal.application.dto.request.CreateNormalFeedDetails;
+import one.colla.teamspace.domain.Teamspace;
+import one.colla.user.domain.User;
 
+@Getter
 @Entity
 @DiscriminatorValue("NORMAL")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "normal_feeds")
 public class NormalFeed extends Feed {
 
 	@Column(name = "content")
 	private String content;
 
+	public static NormalFeed of(
+		final User user,
+		final Teamspace teamspace,
+		final CommonCreateFeedRequest<CreateNormalFeedDetails> createNormalFeedRequest
+	) {
+		CreateNormalFeedDetails createNormalFeedDetails = createNormalFeedRequest.details();
+
+		return new NormalFeed(
+			user,
+			teamspace,
+			createNormalFeedRequest,
+			createNormalFeedDetails.content()
+		);
+	}
+
+	private NormalFeed(
+		final User user,
+		final Teamspace teamspace,
+		final CommonCreateFeedRequest<? extends CreateFeedDetails> commonCreateFeedRequest,
+		final String content
+	) {
+		super(user, teamspace, commonCreateFeedRequest);
+		this.content = content;
+	}
 }

--- a/src/main/java/one/colla/feed/normal/domain/NormalFeedRepository.java
+++ b/src/main/java/one/colla/feed/normal/domain/NormalFeedRepository.java
@@ -1,0 +1,6 @@
+package one.colla.feed.normal.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NormalFeedRepository extends JpaRepository<NormalFeed, Long> {
+}

--- a/src/main/java/one/colla/feed/normal/presentation/NormalFeedController.java
+++ b/src/main/java/one/colla/feed/normal/presentation/NormalFeedController.java
@@ -1,0 +1,41 @@
+package one.colla.feed.normal.presentation;
+
+import java.util.Map;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import one.colla.common.presentation.ApiResponse;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.feed.common.application.dto.request.CommonCreateFeedRequest;
+import one.colla.feed.normal.application.NormalFeedService;
+import one.colla.feed.normal.application.dto.request.CreateNormalFeedDetails;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/teamspaces/{teamspaceId}/feeds/normal")
+public class NormalFeedController {
+	private final NormalFeedService normalFeedService;
+
+	@PostMapping
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Object>> postNormalFeed(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final Long teamspaceId,
+		@RequestBody @Valid final CommonCreateFeedRequest<CreateNormalFeedDetails> createNormalFeedRequest
+	) {
+		normalFeedService.create(userDetails, teamspaceId, createNormalFeedRequest);
+
+		return ResponseEntity.ok().body(
+			ApiResponse.createSuccessResponse(Map.of())
+		);
+	}
+}

--- a/src/main/java/one/colla/file/domain/Attachment.java
+++ b/src/main/java/one/colla/file/domain/Attachment.java
@@ -64,6 +64,14 @@ public class Attachment extends BaseEntity {
 	@OneToMany(mappedBy = "attachment", fetch = FetchType.LAZY)
 	private final List<ChatChannelMessageAttachment> chatChannelMessageAttachments = new ArrayList<>();
 
+	public String getAttachmentNameValue() {
+		return attachmentName.getValue();
+	}
+
+	public String getFileUrlValue() {
+		return fileUrl.getValue();
+	}
+
 	public Attachment(
 		AttachmentName attachmentName,
 		User user,

--- a/src/main/java/one/colla/file/domain/Attachment.java
+++ b/src/main/java/one/colla/file/domain/Attachment.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import one.colla.chat.domain.ChatChannelMessageAttachment;
 import one.colla.common.domain.BaseEntity;
+import one.colla.feed.common.application.dto.request.CommonCreateFeedRequest;
 import one.colla.file.domain.vo.AttachmentName;
 import one.colla.file.domain.vo.FileUrl;
 import one.colla.teamspace.domain.Teamspace;
@@ -63,4 +64,57 @@ public class Attachment extends BaseEntity {
 	@OneToMany(mappedBy = "attachment", fetch = FetchType.LAZY)
 	private final List<ChatChannelMessageAttachment> chatChannelMessageAttachments = new ArrayList<>();
 
+	public Attachment(
+		AttachmentName attachmentName,
+		User user,
+		Teamspace teamspace,
+		AttachmentType attachmentType,
+		Long size,
+		String attachType,
+		FileUrl fileUrl
+	) {
+		this.attachmentName = attachmentName;
+		this.user = user;
+		this.teamspace = teamspace;
+		this.attachmentType = attachmentType;
+		this.size = size;
+		this.attachType = attachType;
+		this.fileUrl = fileUrl;
+	}
+
+	public static Attachment of(
+		User user,
+		Teamspace teamspace,
+		AttachmentType attachmentType,
+		CommonCreateFeedRequest.FileDto fileDto
+	) {
+		AttachmentName attachmentName = AttachmentName.from(fileDto.name());
+		FileUrl fileUrl = FileUrl.from(fileDto.fileUrl());
+		String attachType = getFileExtensionByUrl(fileUrl.getValue());
+
+		return new Attachment(
+			attachmentName,
+			user,
+			teamspace,
+			attachmentType,
+			fileDto.size(),
+			attachType,
+			fileUrl
+		);
+	}
+
+	private static String getFileExtensionByUrl(String url) {
+		if (url == null || url.isEmpty()) {
+			return "";
+		}
+
+		int lastDotIndex = url.lastIndexOf('.');
+		int lastSlashIndex = url.lastIndexOf('/');
+
+		if (lastDotIndex == -1 || lastDotIndex < lastSlashIndex || lastDotIndex == url.length() - 1) {
+			return "";
+		}
+
+		return url.substring(lastDotIndex + 1);
+	}
 }

--- a/src/main/java/one/colla/global/exception/ExceptionCode.java
+++ b/src/main/java/one/colla/global/exception/ExceptionCode.java
@@ -37,6 +37,9 @@ public enum ExceptionCode {
 	FORBIDDEN_TEAMSPACE(HttpStatus.FORBIDDEN, 40307, "접근 권한이 없거나 존재하지 않는 팀 스페이스입니다."),
 	ALREADY_PARTICIPATED(HttpStatus.CONFLICT, 40308, "이미 참가한 사용자입니다."),
 
+	/* FEED-COMMON */
+	NOT_FOUND_FEED(HttpStatus.NOT_FOUND, 47101, "접근 권한이 없거나 존재하지 않는 피드입니다."),
+
 	/* 499xx ETC */
 	NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, 49901, "해당 경로를 찾을 수 없습니다."),
 	METHOD_FORBIDDEN(HttpStatus.METHOD_NOT_ALLOWED, 49902, "지원하지 않는 HTTP 메서드를 사용합니다."),

--- a/src/main/java/one/colla/global/exception/ExceptionCode.java
+++ b/src/main/java/one/colla/global/exception/ExceptionCode.java
@@ -39,6 +39,7 @@ public enum ExceptionCode {
 
 	/* FEED-COMMON */
 	NOT_FOUND_FEED(HttpStatus.NOT_FOUND, 47101, "접근 권한이 없거나 존재하지 않는 피드입니다."),
+	FORBIDDEN_ACCESS_COMMENT(HttpStatus.FORBIDDEN, 47102, "접근 권한이 없거나 존재하지 않는 댓글입니다."),
 
 	/* 499xx ETC */
 	NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, 49901, "해당 경로를 찾을 수 없습니다."),

--- a/src/main/java/one/colla/user/domain/User.java
+++ b/src/main/java/one/colla/user/domain/User.java
@@ -21,7 +21,6 @@ import one.colla.chat.domain.ChatChannelMessage;
 import one.colla.chat.domain.UserChatChannel;
 import one.colla.common.domain.BaseEntity;
 import one.colla.feed.collect.domain.CollectFeedResponse;
-import one.colla.feed.common.domain.Comment;
 import one.colla.feed.common.domain.Feed;
 import one.colla.feed.scheduling.domain.SchedulingFeedAvailableTime;
 import one.colla.feed.vote.domain.VoteFeedSelection;
@@ -121,9 +120,6 @@ public class User extends BaseEntity {
 
 	@OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
 	private final List<Feed> feeds = new ArrayList<>();
-
-	@OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
-	private final List<Comment> comments = new ArrayList<>();
 
 	@OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
 	private final List<CollectFeedResponse> collectFeedResponses = new ArrayList<>();

--- a/src/test/java/one/colla/common/builder/BuilderSupporter.java
+++ b/src/test/java/one/colla/common/builder/BuilderSupporter.java
@@ -3,6 +3,7 @@ package one.colla.common.builder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import one.colla.feed.normal.domain.NormalFeedRepository;
 import one.colla.teamspace.domain.TagRepository;
 import one.colla.teamspace.domain.TeamspaceRepository;
 import one.colla.teamspace.domain.UserTeamspaceRepository;
@@ -23,6 +24,9 @@ public class BuilderSupporter {
 	@Autowired
 	private TagRepository tagRepository;
 
+	@Autowired
+	private NormalFeedRepository normalFeedRepository;
+
 	public UserRepository userRepository() {
 		return userRepository;
 	}
@@ -37,5 +41,9 @@ public class BuilderSupporter {
 
 	public TagRepository tagRepository() {
 		return tagRepository;
+	}
+
+	public NormalFeedRepository normalFeedRepository() {
+		return normalFeedRepository;
 	}
 }

--- a/src/test/java/one/colla/common/builder/TestFixtureBuilder.java
+++ b/src/test/java/one/colla/common/builder/TestFixtureBuilder.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import one.colla.feed.normal.domain.NormalFeed;
 import one.colla.teamspace.domain.Tag;
 import one.colla.teamspace.domain.Teamspace;
 import one.colla.teamspace.domain.UserTeamspace;
@@ -38,5 +39,9 @@ public class TestFixtureBuilder {
 
 	public Tag buildTag(Tag tag) {
 		return bs.tagRepository().save(tag);
+	}
+
+	public NormalFeed buildNormalFeed(final NormalFeed feed) {
+		return bs.normalFeedRepository().save(feed);
 	}
 }

--- a/src/test/java/one/colla/common/fixtures/NormalFeedFixtures.java
+++ b/src/test/java/one/colla/common/fixtures/NormalFeedFixtures.java
@@ -1,0 +1,51 @@
+package one.colla.common.fixtures;
+
+import java.util.List;
+
+import one.colla.feed.common.application.dto.request.CommonCreateFeedRequest;
+import one.colla.feed.normal.application.dto.request.CreateNormalFeedDetails;
+import one.colla.feed.normal.domain.NormalFeed;
+import one.colla.teamspace.domain.UserTeamspace;
+
+public class NormalFeedFixtures {
+	public static final String SAYHI_TITLE = "안녕하세요.";
+	public static final String SAYHI_DETAIL_CONTENT = "반갑습니다 우리 잘해봐요!";
+	public static final String SAYHI_FILE_IMAGE_NAME = "example";
+	public static final String SAYHI_FILE_IMAGE_FILEURL = "https://cdn.colla.so/example";
+	public static final Long SAYHI_FILE_IMAGE_SIZE = 123L;
+
+	public static final String NOTICE_TITLE = "팀 그라운들 룰 공지";
+	public static final String NOTICE_DETAIL_CONTENT = "지각 금지, 존댓말 사용";
+
+	public static NormalFeed SAYHI_NORMAL_FEED(UserTeamspace userTeamspace) {
+		CreateNormalFeedDetails createNormalFeedDetails = new CreateNormalFeedDetails(SAYHI_DETAIL_CONTENT);
+
+		CommonCreateFeedRequest<CreateNormalFeedDetails> createNormalFeedRequest
+			= new CommonCreateFeedRequest<>(SAYHI_TITLE, List.of(), List.of(), createNormalFeedDetails);
+
+		return NormalFeed.of(userTeamspace.getUser(), userTeamspace.getTeamspace(), createNormalFeedRequest);
+	}
+
+	public static NormalFeed SAYHI_NORMAL_FEED_WITH_ATTACHMENTS(UserTeamspace userTeamspace) {
+		CreateNormalFeedDetails createNormalFeedDetails = new CreateNormalFeedDetails(SAYHI_DETAIL_CONTENT);
+		CommonCreateFeedRequest.FileDto fileDto = new CommonCreateFeedRequest.FileDto(
+			SAYHI_FILE_IMAGE_NAME,
+			SAYHI_FILE_IMAGE_FILEURL,
+			SAYHI_FILE_IMAGE_SIZE
+		);
+
+		CommonCreateFeedRequest<CreateNormalFeedDetails> createNormalFeedRequest
+			= new CommonCreateFeedRequest<>(SAYHI_TITLE, List.of(fileDto), List.of(), createNormalFeedDetails);
+
+		return NormalFeed.of(userTeamspace.getUser(), userTeamspace.getTeamspace(), createNormalFeedRequest);
+	}
+
+	public static NormalFeed NOTICE_NORMAL_FEED(UserTeamspace userTeamspace) {
+		CreateNormalFeedDetails createNormalFeedDetails = new CreateNormalFeedDetails(NOTICE_DETAIL_CONTENT);
+
+		CommonCreateFeedRequest<CreateNormalFeedDetails> createNormalFeedRequest
+			= new CommonCreateFeedRequest<>(NOTICE_TITLE, List.of(), List.of(), createNormalFeedDetails);
+
+		return NormalFeed.of(userTeamspace.getUser(), userTeamspace.getTeamspace(), createNormalFeedRequest);
+	}
+}

--- a/src/test/java/one/colla/feed/common/application/CommentServiceTest.java
+++ b/src/test/java/one/colla/feed/common/application/CommentServiceTest.java
@@ -1,0 +1,7 @@
+package one.colla.feed.common.application;
+
+import one.colla.common.ServiceTest;
+
+public class CommentServiceTest extends ServiceTest {
+	// TODO: 테스트 작성 필요
+}

--- a/src/test/java/one/colla/feed/common/application/FeedServiceTest.java
+++ b/src/test/java/one/colla/feed/common/application/FeedServiceTest.java
@@ -1,0 +1,129 @@
+package one.colla.feed.common.application;
+
+import static one.colla.common.fixtures.NormalFeedFixtures.*;
+import static one.colla.common.fixtures.TeamspaceFixtures.*;
+import static one.colla.common.fixtures.UserFixtures.*;
+import static one.colla.common.fixtures.UserTeamspaceFixtures.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import one.colla.common.ServiceTest;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.feed.common.domain.Feed;
+import one.colla.feed.common.domain.FeedRepository;
+import one.colla.feed.common.factory.ReadFeedDetailsFactoryProvider;
+import one.colla.teamspace.application.TeamspaceService;
+import one.colla.teamspace.domain.Teamspace;
+import one.colla.teamspace.domain.UserTeamspace;
+import one.colla.user.domain.User;
+
+class FeedServiceTest extends ServiceTest {
+	@MockBean
+	private TeamspaceService teamspaceService;
+
+	@Autowired
+	private ReadFeedDetailsFactoryProvider readFeedDetailsFactoryProvider;
+
+	@Autowired
+	private FeedRepository feedRepository;
+
+	@Autowired
+	private FeedService feedService;
+
+	User USER1, USER2, RANDOMUSER1, RANDOMUSER2;
+	CustomUserDetails USER1_DETAILS;
+	Teamspace OS_TEAMSPACE, DATABASE_TEAMSPACE;
+	UserTeamspace USER1_OS_USERTEAMSPACE, USER2_DATABASE_USERTEAMSPACE, RANDOMUSER1_OS_USERTEAMSPACE, RANDOMUSER2_DATABASE_USERTEAMSPACE;
+	Feed USER1_OS_SAYHI_NORMAL_FEED, RANDOMUSER1_OS_SAYHI_NORMAL_FEED_WITH_ATTACHMENTS, USER2_DATABASE_NOTICE_NORMAL_FEED, RANDOMUSER2_DATABASE_NOTICE_NORMAL_FEED;
+
+	@BeforeEach
+	void setUp() {
+		// given
+		USER1 = testFixtureBuilder.buildUser(USER1());
+		USER2 = testFixtureBuilder.buildUser(USER2());
+
+		USER1_DETAILS = createCustomUserDetailsByUser(USER1);
+
+		RANDOMUSER1 = testFixtureBuilder.buildUser(RANDOMUSER());
+		RANDOMUSER2 = testFixtureBuilder.buildUser(RANDOMUSER());
+
+		OS_TEAMSPACE = testFixtureBuilder.buildTeamspace(OS_TEAMSPACE());
+		DATABASE_TEAMSPACE = testFixtureBuilder.buildTeamspace(DATABASE_TEAMSPACE());
+
+		USER1_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(LEADER_USERTEAMSPACE(USER1, OS_TEAMSPACE));
+		RANDOMUSER1_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(
+			MEMBER_USERTEAMSPACE(RANDOMUSER1, OS_TEAMSPACE));
+		USER2_DATABASE_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(
+			LEADER_USERTEAMSPACE(USER2, DATABASE_TEAMSPACE));
+		RANDOMUSER2_DATABASE_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(
+			MEMBER_USERTEAMSPACE(RANDOMUSER2, DATABASE_TEAMSPACE));
+
+		USER1_OS_SAYHI_NORMAL_FEED = testFixtureBuilder.buildNormalFeed(SAYHI_NORMAL_FEED(USER1_OS_USERTEAMSPACE));
+		RANDOMUSER1_OS_SAYHI_NORMAL_FEED_WITH_ATTACHMENTS = testFixtureBuilder.buildNormalFeed(
+			SAYHI_NORMAL_FEED_WITH_ATTACHMENTS(RANDOMUSER1_OS_USERTEAMSPACE));
+		USER2_DATABASE_NOTICE_NORMAL_FEED = testFixtureBuilder.buildNormalFeed(
+			NOTICE_NORMAL_FEED(USER2_DATABASE_USERTEAMSPACE));
+		RANDOMUSER2_DATABASE_NOTICE_NORMAL_FEED = testFixtureBuilder.buildNormalFeed(
+			NOTICE_NORMAL_FEED(RANDOMUSER2_DATABASE_USERTEAMSPACE));
+	}
+
+	@Nested
+	@DisplayName("피드 목록 조회 시")
+		// TODO: 테스트 작성 필요
+	class ReadFeedsTest {
+		@Test
+		@DisplayName("피드 목록을 정상적으로 조회한다.")
+		void readFeedsSuccessfully() {
+			// given
+			given(teamspaceService.getUserTeamspace(any(), any())).willReturn(USER1_OS_USERTEAMSPACE);
+
+			// when
+			feedService.readFeeds(
+				USER1_DETAILS,
+				OS_TEAMSPACE.getId(),
+				null,
+				null,
+				5
+			);
+
+		}
+
+		@Test
+		@DisplayName("afterFeedId가 존재하지 않는 경우 예외를 발생시킨다.")
+		void readFeedsAfterFeedNotFound() {
+		}
+
+		@Test
+		@DisplayName("limit이 정상적으로 동작한다.")
+		void readFeedsWithLimit() {
+
+		}
+	}
+
+	@Nested
+	@DisplayName("피드 단건 조회 시")
+	class ReadFeedTest {
+
+		@Test
+		@DisplayName("피드를 정상적으로 조회한다.")
+		void readFeedSuccessfully() {
+		}
+
+		@Test
+		@DisplayName("피드가 존재하지 않는 경우 예외를 발생시킨다.")
+		void readFeedNotFound() {
+		}
+
+		@Test
+		@DisplayName("해당 팀스페이스의 피드가 아닌 피드 id로 조회 시도 시 예외가 발생한다.")
+		void readFeedNotBelongingToTeamspace() {
+		}
+	}
+}

--- a/src/test/java/one/colla/feed/common/domain/FeedRepositoryTest.java
+++ b/src/test/java/one/colla/feed/common/domain/FeedRepositoryTest.java
@@ -1,0 +1,152 @@
+package one.colla.feed.common.domain;
+
+import static one.colla.common.fixtures.NormalFeedFixtures.*;
+import static one.colla.common.fixtures.TeamspaceFixtures.*;
+import static one.colla.common.fixtures.UserFixtures.*;
+import static one.colla.common.fixtures.UserTeamspaceFixtures.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import one.colla.common.RepositoryTest;
+import one.colla.feed.normal.domain.NormalFeed;
+import one.colla.teamspace.domain.Teamspace;
+import one.colla.teamspace.domain.UserTeamspace;
+import one.colla.user.domain.User;
+
+class FeedRepositoryTest extends RepositoryTest {
+	@Autowired
+	private FeedRepository feedRepository;
+
+	User USER1, USER2, RANDOMUSER1, RANDOMUSER2;
+	Teamspace OS_TEAMSPACE, DATABASE_TEAMSPACE;
+	UserTeamspace USER1_OS_USERTEAMSPACE, USER2_DATABASE_USERTEAMSPACE,
+		RANDOMUSER1_OS_SERTEAMSPACE, RANDOMUSER2_DATABASE_USERTEAMSPACE;
+	NormalFeed USER1_OS_SAYHI_NORMAL_FEED,
+		RANDOMUSER1_OS_SAYHI_NORMAL_FEED_WITH_ATTACHMENTS,
+		USER2_DATABASE_NOTICE_NORMAL_FEED,
+		RANDOMUSER2_DATABASE_NOTICE_NORMAL_FEED;
+
+	@BeforeEach
+	void setUp() {
+		// given
+		USER1 = testFixtureBuilder.buildUser(USER1());
+		USER2 = testFixtureBuilder.buildUser(USER2());
+		RANDOMUSER1 = testFixtureBuilder.buildUser(RANDOMUSER());
+		RANDOMUSER2 = testFixtureBuilder.buildUser(RANDOMUSER());
+
+		OS_TEAMSPACE = testFixtureBuilder.buildTeamspace(OS_TEAMSPACE());
+		DATABASE_TEAMSPACE = testFixtureBuilder.buildTeamspace(DATABASE_TEAMSPACE());
+		USER1_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(
+			LEADER_USERTEAMSPACE(USER1, OS_TEAMSPACE)
+		);
+		RANDOMUSER1_OS_SERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(
+			MEMBER_USERTEAMSPACE(RANDOMUSER1, OS_TEAMSPACE)
+		);
+		USER2_DATABASE_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(
+			LEADER_USERTEAMSPACE(USER2, DATABASE_TEAMSPACE)
+		);
+		RANDOMUSER2_DATABASE_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(
+			MEMBER_USERTEAMSPACE(RANDOMUSER2, DATABASE_TEAMSPACE)
+		);
+
+		USER1_OS_SAYHI_NORMAL_FEED = testFixtureBuilder.buildNormalFeed(SAYHI_NORMAL_FEED(USER1_OS_USERTEAMSPACE));
+		RANDOMUSER1_OS_SAYHI_NORMAL_FEED_WITH_ATTACHMENTS = testFixtureBuilder.buildNormalFeed(
+			SAYHI_NORMAL_FEED_WITH_ATTACHMENTS(RANDOMUSER1_OS_SERTEAMSPACE));
+		USER2_DATABASE_NOTICE_NORMAL_FEED = testFixtureBuilder.buildNormalFeed(
+			NOTICE_NORMAL_FEED(USER2_DATABASE_USERTEAMSPACE));
+		RANDOMUSER2_DATABASE_NOTICE_NORMAL_FEED = testFixtureBuilder.buildNormalFeed(
+			NOTICE_NORMAL_FEED(RANDOMUSER2_DATABASE_USERTEAMSPACE));
+	}
+
+	@Test
+	@DisplayName("OS 팀스페이스에서 모든 NormalFeed 목록을 불러올 수 있다.")
+	void testFindFeedsByTeamspaceAndCriteria_OsTeamspace() {
+		// given
+		Pageable pageable = PageRequest.of(0, 10);
+
+		// when
+		List<Feed> osFeeds = feedRepository.findFeedsByTeamspaceAndCriteria(
+			OS_TEAMSPACE, null, NormalFeed.class, pageable);
+
+		// then
+		assertThat(osFeeds).containsExactly(
+			RANDOMUSER1_OS_SAYHI_NORMAL_FEED_WITH_ATTACHMENTS,
+			USER1_OS_SAYHI_NORMAL_FEED
+		);
+	}
+
+	@Test
+	@DisplayName("Database 팀스페이스에서 모든 NormalFeed 목록을 불러올 수 있다.")
+	void testFindFeedsByTeamspaceAndCriteria_DatabaseTeamspace() {
+		// given
+		Pageable pageable = PageRequest.of(0, 10);
+
+		// when
+		List<Feed> databaseFeeds = feedRepository.findFeedsByTeamspaceAndCriteria(
+			DATABASE_TEAMSPACE, null, NormalFeed.class, pageable);
+
+		// then
+		assertThat(databaseFeeds).containsExactly(
+			RANDOMUSER2_DATABASE_NOTICE_NORMAL_FEED,
+			USER2_DATABASE_NOTICE_NORMAL_FEED
+		);
+	}
+
+	@Test
+	@DisplayName("OS 팀스페이스에서 특정 Feed ID 이후의 NormalFeed 목록을 불러올 수 있다.")
+	void testFindFeedsByTeamspaceAndCriteria_OsTeamspaceWithAfter() {
+		// given
+		Pageable pageable = PageRequest.of(0, 10);
+
+		// when
+		List<Feed> osFeedsWithAfter = feedRepository.findFeedsByTeamspaceAndCriteria(
+			OS_TEAMSPACE, RANDOMUSER1_OS_SAYHI_NORMAL_FEED_WITH_ATTACHMENTS.getId(), NormalFeed.class, pageable);
+
+		// then
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(osFeedsWithAfter).doesNotContain(RANDOMUSER1_OS_SAYHI_NORMAL_FEED_WITH_ATTACHMENTS);
+			softly.assertThat(osFeedsWithAfter).contains(USER1_OS_SAYHI_NORMAL_FEED);
+		});
+	}
+
+	@Test
+	@DisplayName("팀스페이스와 피드 ID로 피드를 찾을 수 있다.")
+	void testFindByIdAndTeamspace() {
+		// when
+		Optional<Feed> foundFeed =
+			feedRepository.findByIdAndTeamspace(USER1_OS_SAYHI_NORMAL_FEED.getId(), OS_TEAMSPACE);
+		var notFoundFeed = feedRepository.findByIdAndTeamspace(USER1_OS_SAYHI_NORMAL_FEED.getId(), DATABASE_TEAMSPACE);
+
+		// then
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(foundFeed).isPresent();
+			softly.assertThat(foundFeed.get()).isEqualTo(USER1_OS_SAYHI_NORMAL_FEED);
+			softly.assertThat(notFoundFeed).isNotPresent();
+		});
+	}
+
+	@Test
+	@DisplayName("팀스페이스와 피드 ID로 피드 존재 여부를 확인합니다.")
+	void testExistsByIdAndTeamspace() {
+		// when
+		boolean exists = feedRepository.existsByIdAndTeamspace(USER1_OS_SAYHI_NORMAL_FEED.getId(), OS_TEAMSPACE);
+		boolean notExists = feedRepository.existsByIdAndTeamspace(USER1_OS_SAYHI_NORMAL_FEED.getId(),
+			DATABASE_TEAMSPACE);
+
+		// then
+		SoftAssertions.assertSoftly(softly -> {
+			softly.assertThat(exists).isTrue();
+			softly.assertThat(notExists).isFalse();
+		});
+	}
+}

--- a/src/test/java/one/colla/feed/common/presentation/CommentControllerTest.java
+++ b/src/test/java/one/colla/feed/common/presentation/CommentControllerTest.java
@@ -1,0 +1,204 @@
+package one.colla.feed.common.presentation;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+
+import one.colla.common.ControllerTest;
+import one.colla.common.presentation.ApiResponse;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.common.security.authentication.WithMockCustomUser;
+import one.colla.feed.common.application.CommentService;
+import one.colla.feed.common.application.dto.request.CreateCommentRequest;
+
+@WebMvcTest(CommentController.class)
+class CommentControllerTest extends ControllerTest {
+
+	@MockBean
+	private CommentService commentService;
+
+	@Nested
+	@DisplayName("댓글 생성 문서화")
+	class CreateCommentDocs {
+		Long teamspaceId = 1L;
+		Long feedId = 1L;
+		CreateCommentRequest request;
+
+		@DisplayName("댓글 생성 성공")
+		@WithMockCustomUser
+		@Test
+		void createCommentSuccessfully() throws Exception {
+			request = new CreateCommentRequest("테스트 댓글 내용");
+
+			willDoNothing().given(commentService)
+				.create(any(CustomUserDetails.class), eq(teamspaceId), eq(feedId), any(CreateCommentRequest.class));
+
+			doTest(
+				ApiResponse.createSuccessResponse(Map.of()),
+				status().isOk(),
+				apiDocHelper.createSuccessResponseFields(),
+				"ApiResponse"
+			);
+		}
+
+		private void doTest(
+			ApiResponse<?> response,
+			ResultMatcher statusMatcher,
+			FieldDescriptor[] responseFields,
+			String responseSchemaTitle
+		) throws Exception {
+			mockMvc.perform(
+					RestDocumentationRequestBuilders.post("/api/v1/teamspaces/{teamspaceId}/feeds/{feedId}/comments",
+							teamspaceId, feedId).with(csrf())
+						.content(objectMapper.writeValueAsString(request))
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andExpect(statusMatcher)
+				.andExpect(content().json(objectMapper.writeValueAsString(response)))
+				.andDo(restDocs.document(
+					resource(ResourceSnippetParameters.builder()
+						.tag("comment-feed-controller")
+						.description("피드 댓글을 작성합니다.")
+						.pathParameters(
+							parameterWithName("teamspaceId").description("팀스페이스 ID"),
+							parameterWithName("feedId").description("피드 ID")
+						)
+						.responseFields(responseFields)
+						.requestSchema(Schema.schema("CreateCommentRequest"))
+						.responseSchema(Schema.schema(responseSchemaTitle))
+						.build()
+					)
+				)).andDo(print());
+		}
+	}
+
+	@Nested
+	@DisplayName("댓글 수정 문서화")
+	class PatchCommentDocs {
+		Long teamspaceId = 1L;
+		Long feedId = 1L;
+		Long commentId = 1L;
+		CreateCommentRequest request;
+
+		@DisplayName("댓글 수정 성공")
+		@WithMockCustomUser
+		@Test
+		void patchCommentSuccessfully() throws Exception {
+			request = new CreateCommentRequest("수정된 댓글 내용");
+
+			willDoNothing().given(commentService)
+				.update(any(CustomUserDetails.class), eq(teamspaceId), eq(feedId), eq(commentId),
+					any(CreateCommentRequest.class));
+
+			doTest(
+				ApiResponse.createSuccessResponse(Map.of()),
+				status().isOk(),
+				apiDocHelper.createSuccessResponseFields(),
+				"ApiResponse"
+			);
+
+		}
+
+		private void doTest(
+			ApiResponse<?> response,
+			ResultMatcher statusMatcher,
+			FieldDescriptor[] responseFields,
+			String responseSchemaTitle
+		) throws Exception {
+			mockMvc.perform(
+					RestDocumentationRequestBuilders.patch(
+							"/api/v1/teamspaces/{teamspaceId}/feeds/{feedId}/comments/{commentId}",
+							teamspaceId, feedId, commentId).with(csrf())
+						.content(objectMapper.writeValueAsString(request))
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andExpect(statusMatcher)
+				.andExpect(content().json(objectMapper.writeValueAsString(response)))
+				.andDo(restDocs.document(
+					resource(ResourceSnippetParameters.builder()
+						.tag("comment-feed-controller")
+						.description("피드 댓글을 수정합니다.")
+						.pathParameters(
+							parameterWithName("teamspaceId").description("팀스페이스 ID"),
+							parameterWithName("feedId").description("피드 ID"),
+							parameterWithName("commentId").description("댓글 ID")
+						)
+						.responseFields(responseFields)
+						.requestSchema(Schema.schema("CreateCommentRequest"))
+						.responseSchema(Schema.schema(responseSchemaTitle))
+						.build()
+					)
+				)).andDo(print());
+		}
+	}
+
+	@Nested
+	@DisplayName("댓글 삭제 문서화")
+	class DeleteCommentDocs {
+		Long teamspaceId = 1L;
+		Long feedId = 1L;
+		Long commentId = 1L;
+
+		@DisplayName("댓글 삭제 성공")
+		@WithMockCustomUser
+		@Test
+		void deleteCommentSuccessfully() throws Exception {
+			willDoNothing().given(commentService)
+				.delete(any(CustomUserDetails.class), eq(teamspaceId), eq(feedId), eq(commentId));
+
+			doTest(
+				ApiResponse.createSuccessResponse(Map.of()),
+				status().isOk(),
+				apiDocHelper.createSuccessResponseFields(),
+				"ApiResponse"
+			);
+		}
+
+		private void doTest(
+			ApiResponse<?> response,
+			ResultMatcher statusMatcher,
+			FieldDescriptor[] responseFields,
+			String responseSchemaTitle
+		) throws Exception {
+			mockMvc.perform(
+					RestDocumentationRequestBuilders.delete(
+							"/api/v1/teamspaces/{teamspaceId}/feeds/{feedId}/comments/{commentId}",
+							teamspaceId, feedId, commentId).with(csrf())
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andExpect(statusMatcher)
+				.andExpect(content().json(objectMapper.writeValueAsString(response)))
+				.andDo(restDocs.document(
+					resource(ResourceSnippetParameters.builder()
+						.tag("comment-feed-controller")
+						.description("피드 댓글을 삭제합니다.")
+						.pathParameters(
+							parameterWithName("teamspaceId").description("팀스페이스 ID"),
+							parameterWithName("feedId").description("피드 ID"),
+							parameterWithName("commentId").description("댓글 ID")
+						)
+						.responseFields(responseFields)
+						.responseSchema(Schema.schema(responseSchemaTitle))
+						.build()
+					)
+				)).andDo(print());
+		}
+	}
+}

--- a/src/test/java/one/colla/feed/common/presentation/FeedControllerTest.java
+++ b/src/test/java/one/colla/feed/common/presentation/FeedControllerTest.java
@@ -1,0 +1,276 @@
+package one.colla.feed.common.presentation;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+
+import one.colla.common.ControllerTest;
+import one.colla.common.presentation.ApiResponse;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.common.security.authentication.WithMockCustomUser;
+import one.colla.feed.common.application.FeedService;
+import one.colla.feed.common.application.dto.response.CommentDto;
+import one.colla.feed.common.application.dto.response.CommonReadFeedListResponse;
+import one.colla.feed.common.application.dto.response.CommonReadFeedResponse;
+import one.colla.feed.common.application.dto.response.ReadFeedDetails;
+import one.colla.feed.common.domain.FeedType;
+import one.colla.feed.normal.application.dto.response.ReadNormalFeedDetails;
+
+@WebMvcTest(FeedController.class)
+class FeedControllerTest extends ControllerTest {
+
+	@MockBean
+	private FeedService feedService;
+
+	@Nested
+	@DisplayName("피드 목록 조회 문서화")
+	class GetFeedsDocs {
+		Long teamspaceId = 1L;
+
+		@DisplayName("목록 조회 성공")
+		@WithMockCustomUser
+		@Test
+		void getFeedsSuccessfully() throws Exception {
+			CommonReadFeedResponse.TagDto tagDto
+				= new CommonReadFeedResponse.TagDto(1L, "프론트엔드");
+
+			CommonReadFeedResponse.FeedAuthorDto feedAuthorDto = new CommonReadFeedResponse.FeedAuthorDto(
+				1L,
+				"https://cdn.colla.so/example",
+				"홍길동",
+				tagDto
+			);
+
+			ReadNormalFeedDetails readNormalFeedDetails = ReadNormalFeedDetails.from("content");
+			CommentDto.CommentAuthorDto commentAuthorDto = new CommentDto.CommentAuthorDto(
+				2L,
+				"https://cdn.colla.so/example",
+				"댓글 작성자"
+			);
+			List<CommentDto> comments = List.of(
+				new CommentDto(commentAuthorDto, "댓글 내용", LocalDateTime.of(2021, 1, 1, 0, 0, 0))
+			);
+			// 이미지와 첨부 파일을 추가하여 페이로드에 포함시킵니다.
+			CommonReadFeedResponse.FileDto imageDto = new CommonReadFeedResponse.FileDto(
+				1L, "이미지 이름", "https://cdn.colla.so/image", 1024L
+			);
+			CommonReadFeedResponse.FileDto attachmentDto = new CommonReadFeedResponse.FileDto(
+				1L, "첨부 파일 이름", "https://cdn.colla.so/file", 2048L
+			);
+
+			List<CommonReadFeedResponse.FileDto> images = List.of(imageDto);
+			List<CommonReadFeedResponse.FileDto> attachments = List.of(attachmentDto);
+
+			CommonReadFeedResponse<ReadFeedDetails> commonReadFeedResponse
+				= new CommonReadFeedResponse<>(
+				FeedType.NORMAL,
+				1L,
+				feedAuthorDto,
+				"title",
+				LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+				readNormalFeedDetails,
+				comments,
+				images,
+				attachments
+			);
+
+			List<CommonReadFeedResponse<ReadFeedDetails>> feedResponses = List.of(commonReadFeedResponse);
+			CommonReadFeedListResponse commonReadFeedListResponse = CommonReadFeedListResponse.from(feedResponses);
+
+			given(feedService.readFeeds(any(CustomUserDetails.class), eq(teamspaceId), any(Long.class),
+				any(FeedType.class), any(Integer.class)))
+				.willReturn(commonReadFeedListResponse);
+
+			doTest(
+				ApiResponse.createSuccessResponse(commonReadFeedListResponse),
+				status().isOk(),
+				apiDocHelper.createSuccessResponseFields(
+					fieldWithPath("feeds[].feedType").description("피드 유형"),
+					fieldWithPath("feeds[].feedId").description("피드 ID"),
+					fieldWithPath("feeds[].author.id").description("작성자 ID"),
+					fieldWithPath("feeds[].author.profileImageUrl").description("작성자 프로필 이미지 URL"),
+					fieldWithPath("feeds[].author.username").description("작성자 사용자 이름"),
+					fieldWithPath("feeds[].author.tag.id").description("작성자 사용자 태그 아이디"),
+					fieldWithPath("feeds[].author.tag.name").description("작성자 사용자 태그 이름"),
+					fieldWithPath("feeds[].title").description("피드 제목"),
+					fieldWithPath("feeds[].createdAt").description("피드 생성 일시"),
+					fieldWithPath("feeds[].details.content").description("피드 내용"),
+					fieldWithPath("feeds[].comments[].author.id").description("피드 댓글 작성자 id"),
+					fieldWithPath("feeds[].comments[].author.profileImageUrl").description("피드 댓글 작성자 프로필 사진"),
+					fieldWithPath("feeds[].comments[].author.username").description("피드 댓글 작성자 이름"),
+					fieldWithPath("feeds[].comments[].content").description("피드 댓글 내용"),
+					fieldWithPath("feeds[].comments[].createdAt").description("피드 댓글 작성 일시"),
+					fieldWithPath("feeds[].images[].id").description("이미지 ID"),
+					fieldWithPath("feeds[].images[].name").description("이미지 이름"),
+					fieldWithPath("feeds[].images[].fileUrl").description("이미지 파일 URL"),
+					fieldWithPath("feeds[].images[].size").description("이미지 파일 크기"),
+					fieldWithPath("feeds[].attachments[].id").description("첨부 파일 ID"),
+					fieldWithPath("feeds[].attachments[].name").description("첨부 파일 이름"),
+					fieldWithPath("feeds[].attachments[].fileUrl").description("첨부 파일 URL"),
+					fieldWithPath("feeds[].attachments[].size").description("첨부 파일 크기")
+				),
+				"ApiResponse<CommonReadFeedListResponse>"
+			);
+		}
+
+		private void doTest(
+			ApiResponse<?> response,
+			ResultMatcher statusMatcher,
+			FieldDescriptor[] responseFields,
+			String responseSchemaTitle
+		) throws Exception {
+			mockMvc.perform(get("/api/v1/teamspaces/{teamspaceId}/feeds", teamspaceId)
+					.with(csrf())
+					.queryParam("after", "1")
+					.queryParam("type", String.valueOf(FeedType.NORMAL))
+					.queryParam("limit", "5")
+					.accept(MediaType.APPLICATION_JSON))
+				.andExpect(statusMatcher)
+				.andExpect(content().json(objectMapper.writeValueAsString(response)))
+				.andDo(restDocs.document(
+					resource(ResourceSnippetParameters.builder()
+						.tag("feed-controller-common")
+						.description("피드 목록을 조회합니다.")
+						.queryParameters(
+							parameterWithName("after").description("페이지네이션 커서").optional(),
+							parameterWithName("type").description("피드 종류 필터링").optional(),
+							parameterWithName("limit").description("개수").optional()
+						)
+						.responseFields(responseFields)
+						.responseSchema(Schema.schema(responseSchemaTitle))
+						.build()
+					)
+				)).andDo(print());
+		}
+	}
+
+	@Nested
+	@DisplayName("피드 단건 조회 문서화")
+	class GetFeedDocs {
+		Long teamspaceId = 1L;
+
+		@DisplayName("단건 조회 성공")
+		@WithMockCustomUser
+		@Test
+		void getFeedSuccessfully() throws Exception {
+			CommonReadFeedResponse.TagDto tagDto
+				= new CommonReadFeedResponse.TagDto(1L, "프론트엔드");
+
+			CommonReadFeedResponse.FeedAuthorDto feedAuthorDto = new CommonReadFeedResponse.FeedAuthorDto(
+				1L,
+				"https://cdn.colla.so/example",
+				"홍길동",
+				tagDto
+			);
+
+			ReadNormalFeedDetails readNormalFeedDetails = ReadNormalFeedDetails.from("content");
+			CommentDto.CommentAuthorDto commentAuthorDto = new CommentDto.CommentAuthorDto(
+				2L,
+				"https://cdn.colla.so/example",
+				"댓글 작성자"
+			);
+			List<CommentDto> comments = List.of(
+				new CommentDto(commentAuthorDto, "댓글 내용", LocalDateTime.of(2021, 1, 1, 0, 0, 0))
+			);
+			// 이미지와 첨부 파일을 추가하여 페이로드에 포함시킵니다.
+			CommonReadFeedResponse.FileDto imageDto = new CommonReadFeedResponse.FileDto(
+				1L, "이미지 이름", "https://cdn.colla.so/image", 1024L
+			);
+			CommonReadFeedResponse.FileDto attachmentDto = new CommonReadFeedResponse.FileDto(
+				1L, "첨부 파일 이름", "https://cdn.colla.so/file", 2048L
+			);
+
+			List<CommonReadFeedResponse.FileDto> images = List.of(imageDto);
+			List<CommonReadFeedResponse.FileDto> attachments = List.of(attachmentDto);
+
+			CommonReadFeedResponse<ReadFeedDetails> commonReadFeedResponse
+				= new CommonReadFeedResponse<>(
+				FeedType.NORMAL,
+				1L,
+				feedAuthorDto,
+				"title",
+				LocalDateTime.of(2021, 1, 1, 0, 0, 0),
+				readNormalFeedDetails,
+				comments,
+				images,
+				attachments
+			);
+
+			given(feedService.readFeed(any(CustomUserDetails.class), eq(teamspaceId), eq(1L)))
+				.willReturn(commonReadFeedResponse);
+
+			doTest(
+				ApiResponse.createSuccessResponse(commonReadFeedResponse),
+				status().isOk(),
+				apiDocHelper.createSuccessResponseFields(
+					fieldWithPath("feedType").description("피드 유형"),
+					fieldWithPath("feedId").description("피드 ID"),
+					fieldWithPath("author.id").description("작성자 ID"),
+					fieldWithPath("author.profileImageUrl").description("작성자 프로필 이미지 URL"),
+					fieldWithPath("author.username").description("작성자 사용자 이름"),
+					fieldWithPath("author.tag.id").description("작성자 사용자 태그 아이디"),
+					fieldWithPath("author.tag.name").description("작성자 사용자 태그 이름"),
+					fieldWithPath("title").description("피드 제목"),
+					fieldWithPath("createdAt").description("피드 생성 일시"),
+					fieldWithPath("details.content").description("피드 내용"),
+					fieldWithPath("comments[].author.id").description("피드 댓글 작성자 id"),
+					fieldWithPath("comments[].author.profileImageUrl").description("피드 댓글 작성자 프로필 사진"),
+					fieldWithPath("comments[].author.username").description("피드 댓글 작성자 이름"),
+					fieldWithPath("comments[].content").description("피드 댓글 내용"),
+					fieldWithPath("comments[].createdAt").description("피드 댓글 작성 일시"),
+					fieldWithPath("images[].id").description("이미지 ID"),
+					fieldWithPath("images[].name").description("이미지 이름"),
+					fieldWithPath("images[].fileUrl").description("이미지 파일 URL"),
+					fieldWithPath("images[].size").description("이미지 파일 크기"),
+					fieldWithPath("attachments[].id").description("첨부 파일 ID"),
+					fieldWithPath("attachments[].name").description("첨부 파일 이름"),
+					fieldWithPath("attachments[].fileUrl").description("첨부 파일 URL"),
+					fieldWithPath("attachments[].size").description("첨부 파일 크기")
+				),
+				"ApiResponse<CommonReadFeedResponse>"
+			);
+		}
+
+		private void doTest(
+			ApiResponse<?> response,
+			ResultMatcher statusMatcher,
+			FieldDescriptor[] responseFields,
+			String responseSchemaTitle
+		) throws Exception {
+			mockMvc.perform(get("/api/v1/teamspaces/{teamspaceId}/feeds/{feedId}", teamspaceId, 1L)
+					.with(csrf())
+					.accept(MediaType.APPLICATION_JSON))
+				.andExpect(statusMatcher)
+				.andExpect(content().json(objectMapper.writeValueAsString(response)))
+				.andDo(restDocs.document(
+					resource(ResourceSnippetParameters.builder()
+						.tag("feed-controller-common")
+						.description("피드 단건을 조회합니다.")
+						.responseFields(responseFields)
+						.responseSchema(Schema.schema(responseSchemaTitle))
+						.build()
+					)
+				)).andDo(print());
+		}
+	}
+}

--- a/src/test/java/one/colla/feed/normal/application/NormalFeedServiceTest.java
+++ b/src/test/java/one/colla/feed/normal/application/NormalFeedServiceTest.java
@@ -1,0 +1,7 @@
+package one.colla.feed.normal.application;
+
+import one.colla.common.ServiceTest;
+
+class NormalFeedServiceTest extends ServiceTest {
+
+}

--- a/src/test/java/one/colla/feed/normal/presentation/NormalFeedControllerTest.java
+++ b/src/test/java/one/colla/feed/normal/presentation/NormalFeedControllerTest.java
@@ -1,0 +1,101 @@
+package one.colla.feed.normal.presentation;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+
+import one.colla.common.ControllerTest;
+import one.colla.common.presentation.ApiResponse;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.common.security.authentication.WithMockCustomUser;
+import one.colla.feed.common.application.dto.request.CommonCreateFeedRequest;
+import one.colla.feed.normal.application.NormalFeedService;
+import one.colla.feed.normal.application.dto.request.CreateNormalFeedDetails;
+
+@WebMvcTest(NormalFeedController.class)
+class NormalFeedControllerTest extends ControllerTest {
+
+	@MockBean
+	private NormalFeedService normalFeedService;
+
+	@Nested
+	@DisplayName("일반 피드 작성 문서화")
+	class PostNormalFeedDocs {
+		Long teamspaceId = 1L;
+		CommonCreateFeedRequest<CreateNormalFeedDetails> request;
+
+		@DisplayName("댓글 생성 성공")
+		@WithMockCustomUser
+		@Test
+		void postNormalFeedSuccessfully() throws Exception {
+
+			List<CommonCreateFeedRequest.FileDto> images = List.of(
+				new CommonCreateFeedRequest.FileDto("이미지 제목", "https://cdn.colla.so/example", 123L)
+			);
+			List<CommonCreateFeedRequest.FileDto> attachments = List.of(
+				new CommonCreateFeedRequest.FileDto("파일 제목", "https://cdn.colla.so/example", 123L)
+			);
+			CreateNormalFeedDetails details = new CreateNormalFeedDetails("일반 게시글 내용");
+
+			request = new CommonCreateFeedRequest<>("피드 제목", images, attachments, details);
+
+			willDoNothing().given(normalFeedService)
+				.create(any(CustomUserDetails.class), eq(teamspaceId), any());
+
+			doTest(
+				ApiResponse.createSuccessResponse(Map.of()),
+				status().isOk(),
+				apiDocHelper.createSuccessResponseFields(),
+				"ApiResponse"
+			);
+		}
+
+		private void doTest(
+			ApiResponse<?> response,
+			ResultMatcher statusMatcher,
+			FieldDescriptor[] responseFields,
+			String responseSchemaTitle
+		) throws Exception {
+			mockMvc.perform(
+					RestDocumentationRequestBuilders.post("/api/v1/teamspaces/{teamspaceId}/feeds/normal",
+							teamspaceId).with(csrf())
+						.content(objectMapper.writeValueAsString(request))
+						.contentType(MediaType.APPLICATION_JSON)
+				)
+				.andExpect(statusMatcher)
+				.andExpect(content().json(objectMapper.writeValueAsString(response)))
+				.andDo(restDocs.document(
+					resource(ResourceSnippetParameters.builder()
+						.tag("normal-feed-controller")
+						.description("일반 피드를 작성합니다.")
+						.pathParameters(
+							parameterWithName("teamspaceId").description("팀스페이스 ID")
+						)
+						.responseFields(responseFields)
+						.requestSchema(Schema.schema("CommonCreateFeedRequest<CreateNormalFeedDetails>"))
+						.responseSchema(Schema.schema(responseSchemaTitle))
+						.build()
+					)
+				)).andDo(print());
+		}
+	}
+}


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-backend/issues/59

## ✨ PR 세부 내용
피드 개발을 설계하고, 관련 공통 API를 개발합니다.

- 피드 공통 기능 추상화 진행 및 검증
    - 공통 피드 생성 요청 양식, 공통 피드 조회 응답 양식 확정
- 피드 공통 기능 개발
    - 피드 조회 API 개발
    - 피드 목록 조회 API 개발
- 일반 피드 작성 API 개발
- 피드 댓글 작성 관련 API 개발
- 관련 테스트 일부 작성


## ✅ 리뷰 요구사항

공통 피드 생성 요청과 조회 응답을 위한 Factory와 dto를 작성했습니다. 이부분 위주로 확인해주세요.
일부 테스트는 추후에 작성할 예정입니다!
