### PR TITLE
Feature/#56 chat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,9 @@ dependencies {
     /* AWS S3 */
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
     implementation 'io.awspring.cloud:spring-cloud-starter-aws-secrets-manager-config:2.4.4'
+
+    /* Web Socket */
+    implementation 'org.springframework.boot:spring-boot-starter-websocket:3.2.4'
 }
 
 tasks.register('copyPrivate', Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ dependencies {
 
     /* Web Socket */
     implementation 'org.springframework.boot:spring-boot-starter-websocket:3.2.4'
+    implementation 'org.springframework.security:spring-security-messaging:6.2.4'
 }
 
 tasks.register('copyPrivate', Copy) {

--- a/src/main/java/one/colla/chat/application/ChatChannelService.java
+++ b/src/main/java/one/colla/chat/application/ChatChannelService.java
@@ -13,7 +13,7 @@ import one.colla.chat.application.dto.request.UpdateChatChannelNameRequest;
 import one.colla.chat.application.dto.response.ChatChannelInfoDto;
 import one.colla.chat.application.dto.response.ChatChannelMessageAttachmentDto;
 import one.colla.chat.application.dto.response.ChatChannelMessageAuthorDto;
-import one.colla.chat.application.dto.response.ChatChannelMessageInfoDto;
+import one.colla.chat.application.dto.response.ChatChannelMessageResponse;
 import one.colla.chat.application.dto.response.ChatChannelMessagesResponse;
 import one.colla.chat.application.dto.response.ChatChannelsResponse;
 import one.colla.chat.application.dto.response.CreateChatChannelResponse;
@@ -114,11 +114,11 @@ public class ChatChannelService {
 		validateBeforeChatMessageId(beforeChatMessageId, chatChannel);
 
 		List<ChatChannelMessage> messages = fetchChatChannelMessages(chatChannel, beforeChatMessageId, limit);
-		List<ChatChannelMessageInfoDto> chatChannelMessageInfoDtos = convertToInfoDtos(messages);
+		List<ChatChannelMessageResponse> chatChannelMessageResponses = convertToChatChannelMessageResponse(messages);
 
 		log.info("채팅 채널 메세지 조회 - 팀스페이스 Id: {}, 조회한 사용자 Id: {}, 채팅 채널 Id: {} ",
 			teamspaceId, userDetails.getUserId(), chatChannel.getId());
-		return ChatChannelMessagesResponse.from(chatChannelMessageInfoDtos);
+		return ChatChannelMessagesResponse.from(chatChannelMessageResponses);
 	}
 
 	private ChatChannel getChatChannel(Teamspace teamspace, Long chatChannelId) {
@@ -143,12 +143,12 @@ public class ChatChannelService {
 			chatChannel, beforeChatMessageId, pageRequest);
 	}
 
-	private List<ChatChannelMessageInfoDto> convertToInfoDtos(List<ChatChannelMessage> messages) {
+	private List<ChatChannelMessageResponse> convertToChatChannelMessageResponse(List<ChatChannelMessage> messages) {
 		return messages.stream()
 			.map(msg -> {
 				ChatChannelMessageAuthorDto author = ChatChannelMessageAuthorDto.from(msg.getUser());
 				List<ChatChannelMessageAttachmentDto> attachments = getMessageAttachmentDtos(msg);
-				return ChatChannelMessageInfoDto.of(msg, author, attachments);
+				return ChatChannelMessageResponse.of(msg, author, attachments);
 			}).toList();
 	}
 

--- a/src/main/java/one/colla/chat/application/ChatChannelService.java
+++ b/src/main/java/one/colla/chat/application/ChatChannelService.java
@@ -8,8 +8,11 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import one.colla.chat.application.dto.request.CreateChatChannelRequest;
+import one.colla.chat.application.dto.response.ChatChannelInfoDto;
+import one.colla.chat.application.dto.response.ChatChannelsResponse;
 import one.colla.chat.application.dto.response.CreateChatChannelResponse;
 import one.colla.chat.domain.ChatChannel;
+import one.colla.chat.domain.ChatChannelMessageRepository;
 import one.colla.chat.domain.ChatChannelRepository;
 import one.colla.chat.domain.UserChatChannel;
 import one.colla.chat.domain.UserChatChannelRepository;
@@ -25,28 +28,46 @@ public class ChatChannelService {
 	private final TeamspaceService teamspaceService;
 	private final ChatChannelRepository chatChannelRepository;
 	private final UserChatChannelRepository userChatChannelRepository;
+	private final ChatChannelMessageRepository chatChannelMessageRepository;
 
 	@Transactional
-	public CreateChatChannelResponse createChatChannel(
-		CustomUserDetails userDetails,
-		Long teamspaceId,
+	public CreateChatChannelResponse createChatChannel(CustomUserDetails userDetails, Long teamspaceId,
 		CreateChatChannelRequest request) {
 
-		validateParticipationTeamspace(userDetails, teamspaceId);
-
-		final Teamspace teamspace = teamspaceService.getTeamspace(teamspaceId);
+		final Teamspace teamspace = teamspaceService.getUserTeamspace(userDetails, teamspaceId).getTeamspace();
 		final ChatChannel createdChatChannel = chatChannelRepository.save(
 			ChatChannel.of(teamspace, request.channelName()));
 		final List<UserChatChannel> participants = createdChatChannel.participateAllTeamspaceUser(
 			teamspace.getUserTeamspaces());
-
 		userChatChannelRepository.saveAll(participants);
+
+		teamspace.addChatChannel(createdChatChannel);
 
 		log.info("채팅 채널 생성 - 팀스페이스 Id: {}, 생성한 사용자 Id: {}", createdChatChannel.getId(), userDetails.getUserId());
 		return CreateChatChannelResponse.from(createdChatChannel);
 	}
 
-	private void validateParticipationTeamspace(CustomUserDetails userDetails, Long teamspaceId) {
-		teamspaceService.getUserTeamspace(userDetails, teamspaceId);
+	@Transactional(readOnly = true)
+	public ChatChannelsResponse getChatChannels(CustomUserDetails userDetails, Long teamspaceId) {
+
+		final Teamspace teamspace = teamspaceService.getUserTeamspace(userDetails, teamspaceId).getTeamspace();
+
+		List<ChatChannelInfoDto> chatChannels = teamspace.getChatChannels().stream()
+			.map(this::createChatChannelInfoDto)
+			.toList();
+
+		return ChatChannelsResponse.from(chatChannels);
 	}
+
+	private ChatChannelInfoDto createChatChannelInfoDto(ChatChannel chatChannel) {
+		Long lastChatId = chatChannel.getLastChatId();
+		if (lastChatId == null) {
+			return ChatChannelInfoDto.of(chatChannel, null, null);
+		}
+
+		return chatChannelMessageRepository.findById(lastChatId)
+			.map(msg -> ChatChannelInfoDto.of(chatChannel, msg.getContent().getValue(), msg.getCreatedAt()))
+			.orElseGet(() -> ChatChannelInfoDto.of(chatChannel, null, null));
+	}
+
 }

--- a/src/main/java/one/colla/chat/application/ChatChannelService.java
+++ b/src/main/java/one/colla/chat/application/ChatChannelService.java
@@ -131,6 +131,8 @@ public class ChatChannelService {
 		if (!userTeamspace.getTeamspaceRole().equals(TeamspaceRole.LEADER)) {
 			throw new CommonException(ExceptionCode.ONLY_LEADER_ACCESS);
 		}
+
+		userTeamspace.getTeamspace().removeChatChannel(chatChannel);
 		chatChannelMessageRepository.deleteAllByChatChannel(chatChannel);
 		chatChannelRepository.delete(chatChannel);
 	}

--- a/src/main/java/one/colla/chat/application/ChatChannelService.java
+++ b/src/main/java/one/colla/chat/application/ChatChannelService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import one.colla.chat.application.dto.request.CreateChatChannelRequest;
+import one.colla.chat.application.dto.request.UpdateChatChannelNameRequest;
 import one.colla.chat.application.dto.response.ChatChannelInfoDto;
 import one.colla.chat.application.dto.response.ChatChannelsResponse;
 import one.colla.chat.application.dto.response.CreateChatChannelResponse;
@@ -16,7 +17,10 @@ import one.colla.chat.domain.ChatChannelMessageRepository;
 import one.colla.chat.domain.ChatChannelRepository;
 import one.colla.chat.domain.UserChatChannel;
 import one.colla.chat.domain.UserChatChannelRepository;
+import one.colla.chat.domain.vo.ChatChannelName;
 import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.global.exception.CommonException;
+import one.colla.global.exception.ExceptionCode;
 import one.colla.teamspace.application.TeamspaceService;
 import one.colla.teamspace.domain.Teamspace;
 
@@ -36,14 +40,15 @@ public class ChatChannelService {
 
 		final Teamspace teamspace = teamspaceService.getUserTeamspace(userDetails, teamspaceId).getTeamspace();
 		final ChatChannel createdChatChannel = chatChannelRepository.save(
-			ChatChannel.of(teamspace, request.channelName()));
+			ChatChannel.of(teamspace, request.chatChannelName()));
 		final List<UserChatChannel> participants = createdChatChannel.participateAllTeamspaceUser(
 			teamspace.getUserTeamspaces());
 		userChatChannelRepository.saveAll(participants);
 
 		teamspace.addChatChannel(createdChatChannel);
 
-		log.info("채팅 채널 생성 - 팀스페이스 Id: {}, 생성한 사용자 Id: {}", createdChatChannel.getId(), userDetails.getUserId());
+		log.info("채팅 채널 생성 - 팀스페이스 Id: {}, 생성한 사용자 Id: {}, 생성한 채팅 채널 Id: {}",
+			teamspaceId, userDetails.getUserId(), createdChatChannel.getId());
 		return CreateChatChannelResponse.from(createdChatChannel);
 	}
 
@@ -55,7 +60,7 @@ public class ChatChannelService {
 		List<ChatChannelInfoDto> chatChannels = teamspace.getChatChannels().stream()
 			.map(this::createChatChannelInfoDto)
 			.toList();
-
+		log.info("채팅 채널 목록 조회 - 팀스페이스 Id: {}, 조회한 사용자 Id: {}", teamspaceId, userDetails.getUserId());
 		return ChatChannelsResponse.from(chatChannels);
 	}
 
@@ -70,4 +75,22 @@ public class ChatChannelService {
 			.orElseGet(() -> ChatChannelInfoDto.of(chatChannel, null, null));
 	}
 
+	@Transactional
+	public void updateChatChannelName(CustomUserDetails userDetails, Long teamspaceId,
+		UpdateChatChannelNameRequest request) {
+
+		final Teamspace teamspace = teamspaceService.getUserTeamspace(userDetails, teamspaceId).getTeamspace();
+		ChatChannel chatChannel = teamspace.getChatChannels().stream()
+			.filter(cc -> cc.getId().equals(request.chatChannelId()))
+			.findFirst()
+			.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_CHAT_CHANNEL));
+
+		if (request.chatChannelName() != null) {
+			ChatChannelName chatChannelName = ChatChannelName.from(request.chatChannelName());
+			chatChannel.updateChatChannelName(chatChannelName);
+		}
+
+		log.info("채팅 채널 이름 수정 - 팀스페이스 Id: {}, 수정한 사용자 Id: {}, 수정한 채팅 채널 Id: {}",
+			teamspaceId, userDetails.getUserId(), chatChannel.getId());
+	}
 }

--- a/src/main/java/one/colla/chat/application/ChatChannelService.java
+++ b/src/main/java/one/colla/chat/application/ChatChannelService.java
@@ -29,6 +29,8 @@ import one.colla.global.exception.CommonException;
 import one.colla.global.exception.ExceptionCode;
 import one.colla.teamspace.application.TeamspaceService;
 import one.colla.teamspace.domain.Teamspace;
+import one.colla.teamspace.domain.TeamspaceRole;
+import one.colla.teamspace.domain.UserTeamspace;
 
 @Slf4j
 @Service
@@ -119,6 +121,18 @@ public class ChatChannelService {
 		log.info("채팅 채널 메세지 조회 - 팀스페이스 Id: {}, 조회한 사용자 Id: {}, 채팅 채널 Id: {} ",
 			teamspaceId, userDetails.getUserId(), chatChannel.getId());
 		return ChatChannelMessagesResponse.from(chatChannelMessageResponses);
+	}
+
+	@Transactional
+	public void deleteChatChannel(CustomUserDetails userDetails, Long teamspaceId, Long chatChannelId) {
+		final UserTeamspace userTeamspace = teamspaceService.getUserTeamspace(userDetails, teamspaceId);
+		final ChatChannel chatChannel = getChatChannel(userTeamspace.getTeamspace(), chatChannelId);
+
+		if (!userTeamspace.getTeamspaceRole().equals(TeamspaceRole.LEADER)) {
+			throw new CommonException(ExceptionCode.ONLY_LEADER_ACCESS);
+		}
+		chatChannelMessageRepository.deleteAllByChatChannel(chatChannel);
+		chatChannelRepository.delete(chatChannel);
 	}
 
 	private ChatChannel getChatChannel(Teamspace teamspace, Long chatChannelId) {

--- a/src/main/java/one/colla/chat/application/ChatChannelService.java
+++ b/src/main/java/one/colla/chat/application/ChatChannelService.java
@@ -1,0 +1,52 @@
+package one.colla.chat.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import one.colla.chat.application.dto.request.CreateChatChannelRequest;
+import one.colla.chat.application.dto.response.CreateChatChannelResponse;
+import one.colla.chat.domain.ChatChannel;
+import one.colla.chat.domain.ChatChannelRepository;
+import one.colla.chat.domain.UserChatChannel;
+import one.colla.chat.domain.UserChatChannelRepository;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.teamspace.application.TeamspaceService;
+import one.colla.teamspace.domain.Teamspace;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatChannelService {
+
+	private final TeamspaceService teamspaceService;
+	private final ChatChannelRepository chatChannelRepository;
+	private final UserChatChannelRepository userChatChannelRepository;
+
+	@Transactional
+	public CreateChatChannelResponse createChatChannel(
+		CustomUserDetails userDetails,
+		Long teamspaceId,
+		CreateChatChannelRequest request) {
+
+		validateParticipationTeamspace(userDetails, teamspaceId);
+
+		final Teamspace teamspace = teamspaceService.getTeamspace(teamspaceId);
+		final ChatChannel createdChatChannel = chatChannelRepository.save(
+			ChatChannel.of(teamspace, request.channelName()));
+		final List<UserChatChannel> participants = createdChatChannel.participateAllTeamspaceUser(
+			teamspace.getUserTeamspaces());
+
+		userChatChannelRepository.saveAll(participants);
+
+		log.info("채팅 채널 생성 - 팀스페이스 Id: {}, 생성한 사용자 Id: {}", createdChatChannel.getId(), userDetails.getUserId());
+		return CreateChatChannelResponse.from(createdChatChannel);
+	}
+
+	private void validateParticipationTeamspace(CustomUserDetails userDetails, Long teamspaceId) {
+		teamspaceService.getUserTeamspace(userDetails, teamspaceId);
+	}
+}

--- a/src/main/java/one/colla/chat/application/ChatWebSocketService.java
+++ b/src/main/java/one/colla/chat/application/ChatWebSocketService.java
@@ -1,0 +1,73 @@
+package one.colla.chat.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import one.colla.chat.application.dto.request.ChatCreateRequest;
+import one.colla.chat.application.dto.response.ChatChannelMessageAttachmentDto;
+import one.colla.chat.application.dto.response.ChatChannelMessageAuthorDto;
+import one.colla.chat.application.dto.response.ChatChannelMessageResponse;
+import one.colla.chat.domain.ChatChannel;
+import one.colla.chat.domain.ChatChannelMessage;
+import one.colla.chat.domain.ChatChannelMessageRepository;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.global.exception.CommonException;
+import one.colla.global.exception.ExceptionCode;
+import one.colla.teamspace.application.TeamspaceService;
+import one.colla.teamspace.domain.UserTeamspace;
+import one.colla.user.domain.User;
+import one.colla.user.domain.UserRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatWebSocketService {
+
+	private final TeamspaceService teamspaceService;
+	private final UserRepository userRepository;
+	private final ChatChannelMessageRepository chatChannelMessageRepository;
+
+	// TODO: 소켓 통신이지만 RDB에 너무 많은 접근이 있음. 추후 성능 개선 필요
+	@Transactional
+	public ChatChannelMessageResponse processMessage(
+		ChatCreateRequest request, Long userId, Long teamspaceId, Long chatChannelId) {
+
+		log.info(request.toString());
+
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_USER));
+		CustomUserDetails customUserDetails = CustomUserDetails.from(user);
+
+		UserTeamspace userTeamspace = teamspaceService.getUserTeamspace(customUserDetails, teamspaceId);
+
+		ChatChannel chatChannel = findChatChannel(userTeamspace, chatChannelId);
+
+		ChatChannelMessage chatChannelMessage = ChatChannelMessage.of(
+			user, userTeamspace.getTeamspace(), chatChannel, request);
+
+		chatChannelMessageRepository.save(chatChannelMessage);
+
+		log.info("채팅 메시지 생성 & 저장  - 사용자 Id: {}, 팀스페이스 Id: {}, 채널 Id: {}", userId, teamspaceId, chatChannelId);
+
+		ChatChannelMessageAuthorDto chatChannelMessageAuthorDto = ChatChannelMessageAuthorDto.from(user);
+		List<ChatChannelMessageAttachmentDto> chatChannelMessageAttachmentDtos =
+			chatChannelMessage.getChatChannelMessageAttachments().stream()
+				.map(ChatChannelMessageAttachmentDto::from).toList();
+
+		log.info("채팅 메시지 응답 생성 - 사용자 Id: {}, 팀스페이스 Id: {}, 채널 Id: {}", userId, teamspaceId, chatChannelId);
+
+		return ChatChannelMessageResponse.of(
+			chatChannelMessage, chatChannelMessageAuthorDto, chatChannelMessageAttachmentDtos);
+	}
+
+	private ChatChannel findChatChannel(UserTeamspace userTeamspace, Long chatChannelId) {
+		return userTeamspace.getTeamspace().getChatChannels().stream()
+			.filter(cc -> cc.getId().equals(chatChannelId))
+			.findFirst()
+			.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_CHAT_CHANNEL));
+	}
+}

--- a/src/main/java/one/colla/chat/application/dto/request/ChatCreateRequest.java
+++ b/src/main/java/one/colla/chat/application/dto/request/ChatCreateRequest.java
@@ -1,0 +1,57 @@
+package one.colla.chat.application.dto.request;
+
+import java.util.List;
+
+import org.hibernate.validator.constraints.URL;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import one.colla.chat.domain.ChatType;
+
+public record ChatCreateRequest(
+	@NotNull(message = "채팅 타입을 입력해주세요.")
+	ChatType chatType,
+
+	@Size(max = 1024, message = "채팅 글자 수는 1024자 이하여야 합니다.")
+	String content,
+
+	List<FileDto> images,
+
+	List<FileDto> attachments
+) {
+
+	@AssertTrue(message = "IMAGE 타입의 경우 이미지 파일이 있어야 합니다.")
+	public boolean isImagesValid() {
+		if (chatType == ChatType.IMAGE) {
+			return images != null && !images.isEmpty();
+		}
+		return true;
+	}
+
+	@AssertTrue(message = "FILE 타입의 경우 첨부 파일이 있어야 합니다.")
+	public boolean isAttachmentsValid() {
+		if (chatType == ChatType.FILE) {
+			return attachments != null && !attachments.isEmpty();
+		}
+		return true;
+	}
+
+	public record FileDto(
+		@NotBlank(message = "파일명을 포함해주세요.")
+		@Size(max = 255, message = "파일명은 255자 이하여야 합니다.")
+		String name,
+
+		@NotBlank(message = "파일 경로를 포함해주세요.")
+		@URL(message = "URL 형식이 아닙니다.")
+		@Size(max = 2048, message = "파일 경로는 2048자 이하여야 합니다.")
+		String fileUrl,
+
+		@NotNull(message = "파일 크기를 포함해주세요.")
+		@Positive(message = "파일 크기는 양수여야 합니다.")
+		Long size
+	) {
+	}
+}

--- a/src/main/java/one/colla/chat/application/dto/request/CreateChatChannelRequest.java
+++ b/src/main/java/one/colla/chat/application/dto/request/CreateChatChannelRequest.java
@@ -1,0 +1,12 @@
+package one.colla.chat.application.dto.request;
+
+import org.hibernate.validator.constraints.Length;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateChatChannelRequest(
+	@NotBlank(message = "채널 이름을 입력해주세요.")
+	@Length(min = 1, max = 50, message = "채널 이름은 1자 이상 50자 이하여야 합니다.")
+	String channelName
+) {
+}

--- a/src/main/java/one/colla/chat/application/dto/request/CreateChatChannelRequest.java
+++ b/src/main/java/one/colla/chat/application/dto/request/CreateChatChannelRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 
 public record CreateChatChannelRequest(
 	@NotBlank(message = "채널 이름을 입력해주세요.")
-	@Length(min = 1, max = 50, message = "채널 이름은 1자 이상 50자 이하여야 합니다.")
-	String channelName
+	@Length(min = 1, max = 15, message = "채널 이름은 1자 이상 15자 이하여야 합니다.")
+	String chatChannelName
 ) {
 }

--- a/src/main/java/one/colla/chat/application/dto/request/UpdateChatChannelNameRequest.java
+++ b/src/main/java/one/colla/chat/application/dto/request/UpdateChatChannelNameRequest.java
@@ -1,0 +1,16 @@
+package one.colla.chat.application.dto.request;
+
+import org.hibernate.validator.constraints.Length;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateChatChannelNameRequest(
+	@NotNull(message = "chatChannel Id는 null 일 수 없습니다.")
+	Long chatChannelId,
+
+	@NotBlank(message = "채널 이름을 입력해주세요.")
+	@Length(min = 1, max = 15, message = "채널 이름은 1자 이상 50자 이하여야 합니다.")
+	String chatChannelName
+) {
+}

--- a/src/main/java/one/colla/chat/application/dto/response/ChatChannelInfoDto.java
+++ b/src/main/java/one/colla/chat/application/dto/response/ChatChannelInfoDto.java
@@ -14,12 +14,11 @@ public record ChatChannelInfoDto(
 ) {
 	public static ChatChannelInfoDto of(ChatChannel chatChannel, String lastChatMessage,
 		LocalDateTime lastChatCreatedAt) {
-
 		return ChatChannelInfoDto.builder()
 			.id(chatChannel.getId())
 			.name(chatChannel.getChatChannelName().getValue())
 			.lastChatMessage(lastChatMessage)
-			.lastChatCreatedAt(String.valueOf(lastChatCreatedAt))
+			.lastChatCreatedAt(lastChatCreatedAt != null ? String.valueOf(lastChatCreatedAt) : null)
 			.build();
 	}
 }

--- a/src/main/java/one/colla/chat/application/dto/response/ChatChannelInfoDto.java
+++ b/src/main/java/one/colla/chat/application/dto/response/ChatChannelInfoDto.java
@@ -2,6 +2,10 @@ package one.colla.chat.application.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
 import lombok.Builder;
 import one.colla.chat.domain.ChatChannel;
 
@@ -10,7 +14,9 @@ public record ChatChannelInfoDto(
 	Long id,
 	String name,
 	String lastChatMessage,
-	String lastChatCreatedAt
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
+	LocalDateTime lastChatCreatedAt
 ) {
 	public static ChatChannelInfoDto of(ChatChannel chatChannel, String lastChatMessage,
 		LocalDateTime lastChatCreatedAt) {
@@ -18,7 +24,7 @@ public record ChatChannelInfoDto(
 			.id(chatChannel.getId())
 			.name(chatChannel.getChatChannelName().getValue())
 			.lastChatMessage(lastChatMessage)
-			.lastChatCreatedAt(lastChatCreatedAt != null ? String.valueOf(lastChatCreatedAt) : null)
+			.lastChatCreatedAt(lastChatCreatedAt)
 			.build();
 	}
 }

--- a/src/main/java/one/colla/chat/application/dto/response/ChatChannelInfoDto.java
+++ b/src/main/java/one/colla/chat/application/dto/response/ChatChannelInfoDto.java
@@ -1,0 +1,25 @@
+package one.colla.chat.application.dto.response;
+
+import java.time.LocalDateTime;
+
+import lombok.Builder;
+import one.colla.chat.domain.ChatChannel;
+
+@Builder
+public record ChatChannelInfoDto(
+	Long id,
+	String name,
+	String lastChatMessage,
+	String lastChatCreatedAt
+) {
+	public static ChatChannelInfoDto of(ChatChannel chatChannel, String lastChatMessage,
+		LocalDateTime lastChatCreatedAt) {
+
+		return ChatChannelInfoDto.builder()
+			.id(chatChannel.getId())
+			.name(chatChannel.getChatChannelName().getValue())
+			.lastChatMessage(lastChatMessage)
+			.lastChatCreatedAt(String.valueOf(lastChatCreatedAt))
+			.build();
+	}
+}

--- a/src/main/java/one/colla/chat/application/dto/response/ChatChannelMessageAttachmentDto.java
+++ b/src/main/java/one/colla/chat/application/dto/response/ChatChannelMessageAttachmentDto.java
@@ -1,0 +1,23 @@
+package one.colla.chat.application.dto.response;
+
+import lombok.Builder;
+import one.colla.chat.domain.ChatChannelMessageAttachment;
+
+@Builder
+public record ChatChannelMessageAttachmentDto(
+	Long id,
+	String filename,
+	Long size,
+	String url,
+	String attachType
+) {
+	public static ChatChannelMessageAttachmentDto from(ChatChannelMessageAttachment chatChannelMessageAttachment) {
+		return ChatChannelMessageAttachmentDto.builder()
+			.id(chatChannelMessageAttachment.getAttachment().getId())
+			.filename(chatChannelMessageAttachment.getAttachment().getAttachmentName().getValue())
+			.size(chatChannelMessageAttachment.getAttachment().getSize())
+			.url(chatChannelMessageAttachment.getAttachment().getFileUrl().getValue())
+			.attachType(chatChannelMessageAttachment.getAttachment().getAttachType())
+			.build();
+	}
+}

--- a/src/main/java/one/colla/chat/application/dto/response/ChatChannelMessageAuthorDto.java
+++ b/src/main/java/one/colla/chat/application/dto/response/ChatChannelMessageAuthorDto.java
@@ -1,0 +1,19 @@
+package one.colla.chat.application.dto.response;
+
+import lombok.Builder;
+import one.colla.user.domain.User;
+
+@Builder
+public record ChatChannelMessageAuthorDto(
+	Long id,
+	String username,
+	String profileImageUrl
+) {
+	public static ChatChannelMessageAuthorDto from(User author) {
+		return ChatChannelMessageAuthorDto.builder()
+			.id(author.getId())
+			.username(author.getUsernameValue())
+			.profileImageUrl(author.getProfileImageUrlValue())
+			.build();
+	}
+}

--- a/src/main/java/one/colla/chat/application/dto/response/ChatChannelMessageInfoDto.java
+++ b/src/main/java/one/colla/chat/application/dto/response/ChatChannelMessageInfoDto.java
@@ -1,0 +1,38 @@
+package one.colla.chat.application.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
+import lombok.Builder;
+import one.colla.chat.domain.ChatChannelMessage;
+import one.colla.chat.domain.ChatType;
+
+@Builder
+public record ChatChannelMessageInfoDto(
+	Long id,
+	ChatType type,
+	Long chatChannelId,
+	ChatChannelMessageAuthorDto author,
+	String content,
+	List<ChatChannelMessageAttachmentDto> attachments,
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
+	LocalDateTime createdAt
+) {
+	public static ChatChannelMessageInfoDto of(ChatChannelMessage chatChannelMessage,
+		ChatChannelMessageAuthorDto author, List<ChatChannelMessageAttachmentDto> attachments) {
+		return ChatChannelMessageInfoDto.builder()
+			.id(chatChannelMessage.getId())
+			.type(chatChannelMessage.getChatType())
+			.chatChannelId(chatChannelMessage.getChatChannel().getId())
+			.author(author)
+			.content(chatChannelMessage.getContent().getValue())
+			.attachments(attachments)
+			.createdAt(chatChannelMessage.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/one/colla/chat/application/dto/response/ChatChannelMessageResponse.java
+++ b/src/main/java/one/colla/chat/application/dto/response/ChatChannelMessageResponse.java
@@ -12,7 +12,7 @@ import one.colla.chat.domain.ChatChannelMessage;
 import one.colla.chat.domain.ChatType;
 
 @Builder
-public record ChatChannelMessageInfoDto(
+public record ChatChannelMessageResponse(
 	Long id,
 	ChatType type,
 	Long chatChannelId,
@@ -23,14 +23,20 @@ public record ChatChannelMessageInfoDto(
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
 	LocalDateTime createdAt
 ) {
-	public static ChatChannelMessageInfoDto of(ChatChannelMessage chatChannelMessage,
+	public static ChatChannelMessageResponse of(ChatChannelMessage chatChannelMessage,
 		ChatChannelMessageAuthorDto author, List<ChatChannelMessageAttachmentDto> attachments) {
-		return ChatChannelMessageInfoDto.builder()
+
+		String content = null;
+
+		if (chatChannelMessage.getContent() != null) {
+			content = chatChannelMessage.getContent().getValue();
+		}
+		return ChatChannelMessageResponse.builder()
 			.id(chatChannelMessage.getId())
 			.type(chatChannelMessage.getChatType())
 			.chatChannelId(chatChannelMessage.getChatChannel().getId())
 			.author(author)
-			.content(chatChannelMessage.getContent().getValue())
+			.content(content)
 			.attachments(attachments)
 			.createdAt(chatChannelMessage.getCreatedAt())
 			.build();

--- a/src/main/java/one/colla/chat/application/dto/response/ChatChannelMessagesResponse.java
+++ b/src/main/java/one/colla/chat/application/dto/response/ChatChannelMessagesResponse.java
@@ -1,0 +1,11 @@
+package one.colla.chat.application.dto.response;
+
+import java.util.List;
+
+public record ChatChannelMessagesResponse(
+	List<ChatChannelMessageInfoDto> chatChannelMessages
+) {
+	public static ChatChannelMessagesResponse from(List<ChatChannelMessageInfoDto> chatChannelMessages) {
+		return new ChatChannelMessagesResponse(chatChannelMessages);
+	}
+}

--- a/src/main/java/one/colla/chat/application/dto/response/ChatChannelMessagesResponse.java
+++ b/src/main/java/one/colla/chat/application/dto/response/ChatChannelMessagesResponse.java
@@ -3,9 +3,9 @@ package one.colla.chat.application.dto.response;
 import java.util.List;
 
 public record ChatChannelMessagesResponse(
-	List<ChatChannelMessageInfoDto> chatChannelMessages
+	List<ChatChannelMessageResponse> chatChannelMessages
 ) {
-	public static ChatChannelMessagesResponse from(List<ChatChannelMessageInfoDto> chatChannelMessages) {
+	public static ChatChannelMessagesResponse from(List<ChatChannelMessageResponse> chatChannelMessages) {
 		return new ChatChannelMessagesResponse(chatChannelMessages);
 	}
 }

--- a/src/main/java/one/colla/chat/application/dto/response/ChatChannelsResponse.java
+++ b/src/main/java/one/colla/chat/application/dto/response/ChatChannelsResponse.java
@@ -1,0 +1,10 @@
+package one.colla.chat.application.dto.response;
+
+import java.util.List;
+
+public record ChatChannelsResponse(List<ChatChannelInfoDto> chatChannels) {
+
+	public static ChatChannelsResponse from(List<ChatChannelInfoDto> chatChannels) {
+		return new ChatChannelsResponse(chatChannels);
+	}
+}

--- a/src/main/java/one/colla/chat/application/dto/response/CreateChatChannelResponse.java
+++ b/src/main/java/one/colla/chat/application/dto/response/CreateChatChannelResponse.java
@@ -6,8 +6,7 @@ public record CreateChatChannelResponse(
 	Long chatChannelId
 ) {
 	public static CreateChatChannelResponse from(final ChatChannel chatChannel) {
-		final Long chatChannelId = chatChannel.getId();
-		return new CreateChatChannelResponse(chatChannelId);
+		return new CreateChatChannelResponse(chatChannel.getId());
 	}
 }
 

--- a/src/main/java/one/colla/chat/application/dto/response/CreateChatChannelResponse.java
+++ b/src/main/java/one/colla/chat/application/dto/response/CreateChatChannelResponse.java
@@ -1,0 +1,14 @@
+package one.colla.chat.application.dto.response;
+
+import one.colla.chat.domain.ChatChannel;
+
+public record CreateChatChannelResponse(
+	Long chatChannelId
+) {
+	public static CreateChatChannelResponse from(final ChatChannel chatChannel) {
+		final Long chatChannelId = chatChannel.getId();
+		return new CreateChatChannelResponse(chatChannelId);
+	}
+}
+
+

--- a/src/main/java/one/colla/chat/domain/ChatChannel.java
+++ b/src/main/java/one/colla/chat/domain/ChatChannel.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -16,8 +17,10 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import one.colla.chat.domain.vo.ChatChannelName;
 import one.colla.common.domain.BaseEntity;
 import one.colla.teamspace.domain.Teamspace;
+import one.colla.teamspace.domain.UserTeamspace;
 
 @Getter
 @Entity
@@ -33,8 +36,8 @@ public class ChatChannel extends BaseEntity {
 	@JoinColumn(name = "teamspace_id", nullable = false, updatable = false)
 	private Teamspace teamspace;
 
-	@Column(name = "name", nullable = false, length = 50)
-	private String name;
+	@Embedded
+	private ChatChannelName chatChannelName;
 
 	@Column(name = "last_chat_id")
 	private Long lastChatId;
@@ -45,4 +48,21 @@ public class ChatChannel extends BaseEntity {
 	@OneToMany(mappedBy = "chatChannel", fetch = FetchType.LAZY)
 	private final List<ChatChannelMessage> chatChannelMessages = new ArrayList<>();
 
+	private ChatChannel(Teamspace teamspace, ChatChannelName name) {
+		this.teamspace = teamspace;
+		this.chatChannelName = name;
+	}
+
+	public static ChatChannel of(final Teamspace teamspace, final String channelName) {
+		ChatChannelName name = ChatChannelName.from(channelName);
+		return new ChatChannel(teamspace, name);
+	}
+
+	public List<UserChatChannel> participateAllTeamspaceUser(List<UserTeamspace> userTeamspaces) {
+		List<UserChatChannel> userChatChannelList = userTeamspaces.stream()
+			.map(ut -> UserChatChannel.of(ut.getUser(), this))
+			.toList();
+		this.userChatChannels.addAll(userChatChannelList);
+		return userChatChannelList;
+	}
 }

--- a/src/main/java/one/colla/chat/domain/ChatChannel.java
+++ b/src/main/java/one/colla/chat/domain/ChatChannel.java
@@ -65,4 +65,8 @@ public class ChatChannel extends BaseEntity {
 		this.userChatChannels.addAll(userChatChannelList);
 		return userChatChannelList;
 	}
+
+	public void updateLastChatMessage(Long lastChatMessageId) {
+		this.lastChatId = lastChatMessageId;
+	}
 }

--- a/src/main/java/one/colla/chat/domain/ChatChannel.java
+++ b/src/main/java/one/colla/chat/domain/ChatChannel.java
@@ -69,4 +69,8 @@ public class ChatChannel extends BaseEntity {
 	public void updateLastChatMessage(Long lastChatMessageId) {
 		this.lastChatId = lastChatMessageId;
 	}
+
+	public void updateChatChannelName(ChatChannelName chatChannelName) {
+		this.chatChannelName = chatChannelName;
+	}
 }

--- a/src/main/java/one/colla/chat/domain/ChatChannel.java
+++ b/src/main/java/one/colla/chat/domain/ChatChannel.java
@@ -42,11 +42,8 @@ public class ChatChannel extends BaseEntity {
 	@Column(name = "last_chat_id")
 	private Long lastChatId;
 
-	@OneToMany(mappedBy = "chatChannel", fetch = FetchType.LAZY)
+	@OneToMany(mappedBy = "chatChannel", fetch = FetchType.LAZY, orphanRemoval = true)
 	private final List<UserChatChannel> userChatChannels = new ArrayList<>();
-
-	@OneToMany(mappedBy = "chatChannel", fetch = FetchType.LAZY)
-	private final List<ChatChannelMessage> chatChannelMessages = new ArrayList<>();
 
 	private ChatChannel(Teamspace teamspace, ChatChannelName name) {
 		this.teamspace = teamspace;

--- a/src/main/java/one/colla/chat/domain/ChatChannelMessage.java
+++ b/src/main/java/one/colla/chat/domain/ChatChannelMessage.java
@@ -5,9 +5,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
@@ -21,11 +24,13 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import one.colla.chat.domain.vo.ChatChannelMessageContent;
 import one.colla.user.domain.User;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "chat_channel_messages")
 public class ChatChannelMessage {
 
@@ -45,8 +50,8 @@ public class ChatChannelMessage {
 	@Enumerated(EnumType.STRING)
 	private ChatType chatType;
 
-	@Column(name = "content")
-	private String content;
+	@Embedded
+	private ChatChannelMessageContent content;
 
 	@CreatedDate
 	@Column(name = "created_at", nullable = false, updatable = false)
@@ -54,5 +59,18 @@ public class ChatChannelMessage {
 
 	@OneToMany(mappedBy = "chatChannelMessage", fetch = FetchType.LAZY)
 	private final List<ChatChannelMessageAttachment> chatChannelMessageAttachments = new ArrayList<>();
+
+	private ChatChannelMessage(User user, ChatChannel chatChannel, ChatType chatType,
+		ChatChannelMessageContent content) {
+		this.user = user;
+		this.chatChannel = chatChannel;
+		this.chatType = chatType;
+		this.content = content;
+	}
+
+	public static ChatChannelMessage of(User user, ChatChannel chatChannel, ChatType chatType, String content) {
+		ChatChannelMessageContent chatChannelMessageContent = ChatChannelMessageContent.from(content);
+		return new ChatChannelMessage(user, chatChannel, chatType, chatChannelMessageContent);
+	}
 
 }

--- a/src/main/java/one/colla/chat/domain/ChatChannelMessage.java
+++ b/src/main/java/one/colla/chat/domain/ChatChannelMessage.java
@@ -62,7 +62,8 @@ public class ChatChannelMessage {
 	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
 
-	@OneToMany(mappedBy = "chatChannelMessage", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+	@OneToMany(mappedBy = "chatChannelMessage", fetch = FetchType.LAZY, cascade = CascadeType.PERSIST,
+		orphanRemoval = true)
 	private final List<ChatChannelMessageAttachment> chatChannelMessageAttachments = new ArrayList<>();
 
 	private ChatChannelMessage(User user, Teamspace teamspace, ChatChannel chatChannel,

--- a/src/main/java/one/colla/chat/domain/ChatChannelMessageAttachment.java
+++ b/src/main/java/one/colla/chat/domain/ChatChannelMessageAttachment.java
@@ -21,7 +21,7 @@ import one.colla.file.domain.Attachment;
 public class ChatChannelMessageAttachment {
 
 	@EmbeddedId
-	private ChatChannelMessageAttachmentId chatChannelMessageAttachmentId;
+	private ChatChannelMessageAttachmentId chatChannelMessageAttachmentId = new ChatChannelMessageAttachmentId();
 
 	@MapsId("chatChannelMessageId")
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -32,6 +32,15 @@ public class ChatChannelMessageAttachment {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "attachment_id", nullable = false, updatable = false)
 	private Attachment attachment;
+
+	private ChatChannelMessageAttachment(ChatChannelMessage chatChannelMessage, Attachment attachment) {
+		this.chatChannelMessage = chatChannelMessage;
+		this.attachment = attachment;
+	}
+
+	public static ChatChannelMessageAttachment of(ChatChannelMessage chatChannelMessage, Attachment attachment) {
+		return new ChatChannelMessageAttachment(chatChannelMessage, attachment);
+	}
 
 	public static class ChatChannelMessageAttachmentId extends CompositeKeyBase {
 		@Column(name = "chat_channel_message_id")

--- a/src/main/java/one/colla/chat/domain/ChatChannelMessageAttachment.java
+++ b/src/main/java/one/colla/chat/domain/ChatChannelMessageAttachment.java
@@ -1,5 +1,6 @@
 package one.colla.chat.domain;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
@@ -29,7 +30,7 @@ public class ChatChannelMessageAttachment {
 	private ChatChannelMessage chatChannelMessage;
 
 	@MapsId("attachmentId")
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	@JoinColumn(name = "attachment_id", nullable = false, updatable = false)
 	private Attachment attachment;
 

--- a/src/main/java/one/colla/chat/domain/ChatChannelMessageRepository.java
+++ b/src/main/java/one/colla/chat/domain/ChatChannelMessageRepository.java
@@ -1,0 +1,6 @@
+package one.colla.chat.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatChannelMessageRepository extends JpaRepository<ChatChannelMessage, Long> {
+}

--- a/src/main/java/one/colla/chat/domain/ChatChannelMessageRepository.java
+++ b/src/main/java/one/colla/chat/domain/ChatChannelMessageRepository.java
@@ -1,6 +1,35 @@
 package one.colla.chat.domain;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import io.lettuce.core.dynamic.annotation.Param;
+import io.micrometer.common.lang.Nullable;
 
 public interface ChatChannelMessageRepository extends JpaRepository<ChatChannelMessage, Long> {
+
+	/**
+	 * 주어진 채팅 채널과 기준에 따라 채팅 메시지를 찾습니다.
+	 * 결과는 생성 날짜 기준 내림차순으로 정렬됩니다.
+	 *
+	 * @param chatChannel 채팅 메시지를 필터링할 채팅 채널
+	 * @param before 선택적 채팅 메시지 ID로, 이 채팅 메시지의 생성 날짜 이전에 생성된 채팅 메시지들을 필터링합니다
+	 * @param pageable 페이징 정보
+	 * @return 주어진 기준에 맞는 채팅 메시지 목록
+	 */
+	@Query("SELECT msg FROM ChatChannelMessage msg WHERE msg.chatChannel = :chatChannel "
+		+ "AND (:before IS NULL "
+		+ "OR msg.createdAt < (SELECT bmsg.createdAt FROM ChatChannelMessage bmsg WHERE bmsg.id = :before)) "
+		+ "ORDER BY msg.createdAt DESC")
+	List<ChatChannelMessage> findChatChannelMessageByChatChannelAndCriteria(
+		@Param("chatChannel") ChatChannel chatChannel,
+		@Param("before") @Nullable Long before,
+		Pageable pageable
+	);
+
+	Optional<ChatChannelMessage> findByIdAndChatChannel(Long beforeChatMessageId, ChatChannel chatChannel);
 }

--- a/src/main/java/one/colla/chat/domain/ChatChannelMessageRepository.java
+++ b/src/main/java/one/colla/chat/domain/ChatChannelMessageRepository.java
@@ -32,4 +32,6 @@ public interface ChatChannelMessageRepository extends JpaRepository<ChatChannelM
 	);
 
 	Optional<ChatChannelMessage> findByIdAndChatChannel(Long beforeChatMessageId, ChatChannel chatChannel);
+
+	void deleteAllByChatChannel(ChatChannel chatChannel);
 }

--- a/src/main/java/one/colla/chat/domain/ChatChannelRepository.java
+++ b/src/main/java/one/colla/chat/domain/ChatChannelRepository.java
@@ -1,0 +1,6 @@
+package one.colla.chat.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatChannelRepository extends JpaRepository<ChatChannel, Long> {
+}

--- a/src/main/java/one/colla/chat/domain/UserChatChannel.java
+++ b/src/main/java/one/colla/chat/domain/UserChatChannel.java
@@ -22,7 +22,7 @@ import one.colla.user.domain.User;
 public class UserChatChannel extends BaseEntity {
 
 	@EmbeddedId
-	private UserChatChannelId userChatChannelId;
+	private UserChatChannelId userChatChannelId = new UserChatChannelId();
 
 	@MapsId("userId")
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -36,6 +36,15 @@ public class UserChatChannel extends BaseEntity {
 
 	@Column(name = "last_read_message_id")
 	private Long lastReadMessageId;
+
+	private UserChatChannel(User user, ChatChannel chatChannel) {
+		this.user = user;
+		this.chatChannel = chatChannel;
+	}
+
+	public static UserChatChannel of(User user, ChatChannel chatChannel) {
+		return new UserChatChannel(user, chatChannel);
+	}
 
 	public static class UserChatChannelId extends CompositeKeyBase {
 		@Column(name = "user_id")

--- a/src/main/java/one/colla/chat/domain/UserChatChannelRepository.java
+++ b/src/main/java/one/colla/chat/domain/UserChatChannelRepository.java
@@ -1,0 +1,6 @@
+package one.colla.chat.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserChatChannelRepository extends JpaRepository<UserChatChannel, Long> {
+}

--- a/src/main/java/one/colla/chat/domain/vo/ChatChannelMessageContent.java
+++ b/src/main/java/one/colla/chat/domain/vo/ChatChannelMessageContent.java
@@ -1,0 +1,35 @@
+package one.colla.chat.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import one.colla.global.exception.VoException;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+@Getter
+public class ChatChannelMessageContent {
+	private static final int MAX_LENGTH = 1024;
+
+	@Column(name = "content", length = 1024)
+	private String value;
+
+	private ChatChannelMessageContent(final String value) {
+		validate(value);
+		this.value = value;
+	}
+
+	public static ChatChannelMessageContent from(String chatChannelMessageContent) {
+		return new ChatChannelMessageContent(chatChannelMessageContent);
+	}
+
+	private void validate(final String value) {
+		if (value.length() > MAX_LENGTH) {
+			throw new VoException("채팅 메시지는 " + MAX_LENGTH + "자 이하여야 합니다.");
+		}
+	}
+}

--- a/src/main/java/one/colla/chat/domain/vo/ChatChannelName.java
+++ b/src/main/java/one/colla/chat/domain/vo/ChatChannelName.java
@@ -1,0 +1,47 @@
+package one.colla.chat.domain.vo;
+
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import one.colla.global.exception.VoException;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+@Getter
+public class ChatChannelName {
+	private static final int MIN_LENGTH = 1;
+	private static final int MAX_LENGTH = 15;
+
+	@Column(name = "name", nullable = false, length = 50)
+	private String value;
+
+	private ChatChannelName(final String value) {
+		validate(value);
+		this.value = value;
+	}
+
+	public static ChatChannelName from(String chatChannelName) {
+		return new ChatChannelName(chatChannelName);
+	}
+
+	private void validate(final String value) {
+		if (Objects.isNull(value)) {
+			throw new VoException("채팅 채널 이름은 null 일 수 없습니다.");
+		}
+		if (value.isEmpty()) {
+			throw new VoException("채팅 채널 이름은 " + MIN_LENGTH + "자 이상이어야 합니다.");
+		}
+		if (value.isBlank()) {
+			throw new VoException("채팅 채널 이름은 공백일 수 없습니다.");
+		}
+		if (value.length() > MAX_LENGTH) {
+			throw new VoException("채팅 채널 이름은 " + MIN_LENGTH + "자 이상, " + MAX_LENGTH + "자 이하여야 합니다.");
+		}
+	}
+}

--- a/src/main/java/one/colla/chat/presentation/ChatController.java
+++ b/src/main/java/one/colla/chat/presentation/ChatController.java
@@ -1,0 +1,41 @@
+package one.colla.chat.presentation;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import one.colla.chat.application.ChatChannelService;
+import one.colla.chat.application.dto.request.CreateChatChannelRequest;
+import one.colla.chat.application.dto.response.CreateChatChannelResponse;
+import one.colla.common.presentation.ApiResponse;
+import one.colla.common.security.authentication.CustomUserDetails;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/teamspaces/{teamspaceId}/chat-channels")
+public class ChatController {
+
+	private final ChatChannelService chatChannelService;
+
+	@PostMapping
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<CreateChatChannelResponse>> createChatChannel(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final Long teamspaceId,
+		@RequestBody @Valid final CreateChatChannelRequest request) {
+
+		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.createSuccessResponse(
+			chatChannelService.createChatChannel(userDetails, teamspaceId, request)));
+	}
+
+}
+
+

--- a/src/main/java/one/colla/chat/presentation/ChatController.java
+++ b/src/main/java/one/colla/chat/presentation/ChatController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -55,9 +56,22 @@ public class ChatController {
 			.body(ApiResponse.createSuccessResponse(chatChannelService.getChatChannels(userDetails, teamspaceId)));
 	}
 
+	@DeleteMapping("/{chatChannelId}")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<Object>> deleteChatChannel(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final Long teamspaceId,
+		@PathVariable final Long chatChannelId) {
+
+		chatChannelService.deleteChatChannel(userDetails, teamspaceId, chatChannelId);
+
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccessResponse(Map.of()));
+	}
+
 	@PatchMapping("/name")
 	@PreAuthorize("isAuthenticated()")
-	public ResponseEntity<ApiResponse<?>> updateChatChannelName(
+	public ResponseEntity<ApiResponse<Object>> updateChatChannelName(
 		@AuthenticationPrincipal final CustomUserDetails userDetails,
 		@PathVariable final Long teamspaceId,
 		@RequestBody @Valid final UpdateChatChannelNameRequest request) {

--- a/src/main/java/one/colla/chat/presentation/ChatController.java
+++ b/src/main/java/one/colla/chat/presentation/ChatController.java
@@ -12,13 +12,16 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import one.colla.chat.application.ChatChannelService;
 import one.colla.chat.application.dto.request.CreateChatChannelRequest;
 import one.colla.chat.application.dto.request.UpdateChatChannelNameRequest;
+import one.colla.chat.application.dto.response.ChatChannelMessagesResponse;
 import one.colla.chat.application.dto.response.ChatChannelsResponse;
 import one.colla.chat.application.dto.response.CreateChatChannelResponse;
 import one.colla.common.presentation.ApiResponse;
@@ -61,6 +64,21 @@ public class ChatController {
 
 		chatChannelService.updateChatChannelName(userDetails, teamspaceId, request);
 		return ResponseEntity.ok().body(ApiResponse.createSuccessResponse(Map.of()));
+	}
+
+	@GetMapping("/{chatChannelId}/messages")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<ChatChannelMessagesResponse>> getChatChannelMessages(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final Long teamspaceId,
+		@PathVariable final Long chatChannelId,
+		@RequestParam(value = "before", required = false) final Long beforeChatMessageId,
+		@RequestParam(value = "limit", defaultValue = "50") @Valid @Positive final int limit) {
+
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccessResponse(
+				chatChannelService.getChatChanelMessages(
+					userDetails, teamspaceId, chatChannelId, beforeChatMessageId, limit)));
 	}
 
 }

--- a/src/main/java/one/colla/chat/presentation/ChatController.java
+++ b/src/main/java/one/colla/chat/presentation/ChatController.java
@@ -4,6 +4,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,6 +15,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import one.colla.chat.application.ChatChannelService;
 import one.colla.chat.application.dto.request.CreateChatChannelRequest;
+import one.colla.chat.application.dto.response.ChatChannelsResponse;
 import one.colla.chat.application.dto.response.CreateChatChannelResponse;
 import one.colla.common.presentation.ApiResponse;
 import one.colla.common.security.authentication.CustomUserDetails;
@@ -34,6 +36,16 @@ public class ChatController {
 
 		return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.createSuccessResponse(
 			chatChannelService.createChatChannel(userDetails, teamspaceId, request)));
+	}
+
+	@GetMapping
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<ChatChannelsResponse>> getChatChannels(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final Long teamspaceId) {
+
+		return ResponseEntity.ok()
+			.body(ApiResponse.createSuccessResponse(chatChannelService.getChatChannels(userDetails, teamspaceId)));
 	}
 
 }

--- a/src/main/java/one/colla/chat/presentation/ChatController.java
+++ b/src/main/java/one/colla/chat/presentation/ChatController.java
@@ -1,10 +1,13 @@
 package one.colla.chat.presentation;
 
+import java.util.Map;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,6 +18,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import one.colla.chat.application.ChatChannelService;
 import one.colla.chat.application.dto.request.CreateChatChannelRequest;
+import one.colla.chat.application.dto.request.UpdateChatChannelNameRequest;
 import one.colla.chat.application.dto.response.ChatChannelsResponse;
 import one.colla.chat.application.dto.response.CreateChatChannelResponse;
 import one.colla.common.presentation.ApiResponse;
@@ -46,6 +50,17 @@ public class ChatController {
 
 		return ResponseEntity.ok()
 			.body(ApiResponse.createSuccessResponse(chatChannelService.getChatChannels(userDetails, teamspaceId)));
+	}
+
+	@PatchMapping("/name")
+	@PreAuthorize("isAuthenticated()")
+	public ResponseEntity<ApiResponse<?>> updateChatChannelName(
+		@AuthenticationPrincipal final CustomUserDetails userDetails,
+		@PathVariable final Long teamspaceId,
+		@RequestBody @Valid final UpdateChatChannelNameRequest request) {
+
+		chatChannelService.updateChatChannelName(userDetails, teamspaceId, request);
+		return ResponseEntity.ok().body(ApiResponse.createSuccessResponse(Map.of()));
 	}
 
 }

--- a/src/main/java/one/colla/chat/presentation/ChatWebSocketController.java
+++ b/src/main/java/one/colla/chat/presentation/ChatWebSocketController.java
@@ -1,0 +1,51 @@
+package one.colla.chat.presentation;
+
+import java.util.Map;
+
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import one.colla.chat.application.ChatWebSocketService;
+import one.colla.chat.application.dto.request.ChatCreateRequest;
+import one.colla.chat.application.dto.response.ChatChannelMessageResponse;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+public class ChatWebSocketController {
+
+	private final SimpMessagingTemplate template;
+	private final ChatWebSocketService chatWebSocketService;
+
+	@MessageMapping("/teamspaces/{teamspaceId}/chat-channels/{chatChannelId}/messages")
+	public void sendMessage(
+		@Payload @Valid ChatCreateRequest request,
+		@DestinationVariable Long teamspaceId,
+		@DestinationVariable Long chatChannelId,
+		StompHeaderAccessor headerAccessor) {
+
+		Long userId = getUserIdFromHeaderAccessor(headerAccessor);
+
+		ChatChannelMessageResponse response = chatWebSocketService.processMessage(
+			request, userId, teamspaceId, chatChannelId);
+		template.convertAndSend("/topic/teamspaces/" + teamspaceId + "/chat-channels/" + chatChannelId + "/messages",
+			response);
+		log.info("채팅 메시지 전송 - 사용자 Id: {}, 팀스페이스 Id: {}, 채널 Id: {}", userId, teamspaceId, chatChannelId);
+	}
+
+	private Long getUserIdFromHeaderAccessor(StompHeaderAccessor headerAccessor) {
+		Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+		if (sessionAttributes == null) {
+			throw new IllegalArgumentException("Session attributes are required");
+		}
+		return (Long)sessionAttributes.get("userId");
+	}
+
+}

--- a/src/main/java/one/colla/chat/presentation/WebSocketEventListener.java
+++ b/src/main/java/one/colla/chat/presentation/WebSocketEventListener.java
@@ -1,0 +1,24 @@
+package one.colla.chat.presentation;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionConnectEvent;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+public class WebSocketEventListener {
+
+	@EventListener
+	public void handleWebSocketConnectListener(SessionConnectEvent event) {
+		log.info("소켓 연결 시작- 사용자 ID: {}", event.getMessage().getHeaders().get("simpSessionAttributes"));
+
+	}
+
+	@EventListener
+	public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+		log.info("소켓 연결 해제 - 사용자 ID: {}", event.getMessage().getHeaders().get("simpSessionAttributes"));
+	}
+}

--- a/src/main/java/one/colla/common/security/interceptor/HttpHandshakeInterceptor.java
+++ b/src/main/java/one/colla/common/security/interceptor/HttpHandshakeInterceptor.java
@@ -72,7 +72,6 @@ public class HttpHandshakeInterceptor implements HandshakeInterceptor {
 				.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_USER));
 
 			attributes.put("userId", user.getId());
-			log.info("WebSocket 연결 성공 - 사용자 Id: {}", userId);
 			return true;
 		} catch (JwtException e) {
 			log.error("유효하지 않은 접근 토큰: {}", e.getMessage());

--- a/src/main/java/one/colla/common/security/interceptor/HttpHandshakeInterceptor.java
+++ b/src/main/java/one/colla/common/security/interceptor/HttpHandshakeInterceptor.java
@@ -1,0 +1,87 @@
+package one.colla.common.security.interceptor;
+
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import one.colla.common.security.jwt.JwtClaims;
+import one.colla.common.security.jwt.access.AccessTokenClaimKeys;
+import one.colla.common.security.jwt.access.AccessTokenProvider;
+import one.colla.global.exception.CommonException;
+import one.colla.global.exception.ExceptionCode;
+import one.colla.user.domain.User;
+import one.colla.user.domain.UserRepository;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class HttpHandshakeInterceptor implements HandshakeInterceptor {
+
+	private final AccessTokenProvider accessTokenProvider;
+	private final UserRepository userRepository;
+
+	@Override
+	public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler,
+		Map<String, Object> attributes) throws Exception {
+
+		if (request instanceof ServletServerHttpRequest) {
+			return handleHandshake((ServletServerHttpRequest)request, response, attributes);
+		}
+
+		log.warn("요청이 ServletServerHttpRequest 타입이 아님");
+		response.setStatusCode(HttpStatus.BAD_REQUEST);
+		return false;
+	}
+
+	@Override
+	public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler,
+		Exception ex) {
+		// 핸드셰이크 후 처리 로직 (필요 시)
+	}
+
+	private boolean handleHandshake(ServletServerHttpRequest servletRequest, ServerHttpResponse response,
+		Map<String, Object> attributes) {
+		HttpServletRequest request = servletRequest.getServletRequest();
+		String accessToken = request.getParameter("accessToken");
+
+		if (accessToken == null) {
+			log.warn("액세스 토큰이 비어있음");
+			response.setStatusCode(HttpStatus.BAD_REQUEST);
+			return false;
+		}
+
+		return validateAccessToken(accessToken, response, attributes);
+	}
+
+	private boolean validateAccessToken(String accessToken, ServerHttpResponse response,
+		Map<String, Object> attributes) {
+		try {
+			JwtClaims claims = accessTokenProvider.getJwtClaimsFromToken(accessToken);
+			String userId = (String)claims.getClaims().get(AccessTokenClaimKeys.USER_ID.getValue());
+			User user = userRepository.findById(Long.valueOf(userId))
+				.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_USER));
+
+			attributes.put("userId", user.getId());
+			log.info("WebSocket 연결 성공 - 사용자 Id: {}", userId);
+			return true;
+		} catch (JwtException e) {
+			log.error("유효하지 않은 접근 토큰: {}", e.getMessage());
+			response.setStatusCode(HttpStatus.UNAUTHORIZED);
+			return false;
+		} catch (Exception e) {
+			log.error("WebSocket 핸드셰이크 중 오류 발생: {}", e.getMessage());
+			response.setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR);
+			return false;
+		}
+	}
+}

--- a/src/main/java/one/colla/file/domain/Attachment.java
+++ b/src/main/java/one/colla/file/domain/Attachment.java
@@ -19,6 +19,7 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import one.colla.chat.application.dto.request.ChatCreateRequest;
 import one.colla.chat.domain.ChatChannelMessageAttachment;
 import one.colla.common.domain.BaseEntity;
 import one.colla.feed.common.application.dto.request.CommonCreateFeedRequest;
@@ -88,6 +89,27 @@ public class Attachment extends BaseEntity {
 		this.size = size;
 		this.attachType = attachType;
 		this.fileUrl = fileUrl;
+	}
+
+	public static Attachment createChatChannelMessageAttachment(
+		User user,
+		Teamspace teamspace,
+		AttachmentType attachmentType,
+		ChatCreateRequest.FileDto fileDto
+	) {
+		AttachmentName attachmentName = AttachmentName.from(fileDto.name());
+		FileUrl fileUrl = FileUrl.from(fileDto.fileUrl());
+		String attachType = getFileExtensionByUrl(fileUrl.getValue());
+
+		return new Attachment(
+			attachmentName,
+			user,
+			teamspace,
+			attachmentType,
+			fileDto.size(),
+			attachType,
+			fileUrl
+		);
 	}
 
 	public static Attachment of(

--- a/src/main/java/one/colla/global/config/WebSocketConfig.java
+++ b/src/main/java/one/colla/global/config/WebSocketConfig.java
@@ -2,27 +2,38 @@ package one.colla.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
+import lombok.RequiredArgsConstructor;
+import one.colla.common.security.interceptor.HttpHandshakeInterceptor;
+
+@Order(Ordered.HIGHEST_PRECEDENCE + 99)
+@RequiredArgsConstructor
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 	@Value("${spring.websocket.allowed-origins}")
 	private String[] allowedOrigins;
 
+	private final HttpHandshakeInterceptor httpHandshakeInterceptor;
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		registry.enableSimpleBroker("/topic", "/queue");
+		registry.setApplicationDestinationPrefixes("/app");
+	}
+
 	@Override
 	public void registerStompEndpoints(StompEndpointRegistry registry) {
-		registry.addEndpoint("/ws")
+		registry.addEndpoint("/ws-stomp")
+			.addInterceptors(httpHandshakeInterceptor)
 			.setAllowedOriginPatterns(allowedOrigins)
 			.withSockJS();
 	}
 
-	@Override
-	public void configureMessageBroker(MessageBrokerRegistry registry) {
-		registry.setApplicationDestinationPrefixes("/pub");
-		registry.enableSimpleBroker("/sub");
-	}
 }

--- a/src/main/java/one/colla/global/config/WebSocketConfig.java
+++ b/src/main/java/one/colla/global/config/WebSocketConfig.java
@@ -1,0 +1,28 @@
+package one.colla.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+	@Value("${spring.websocket.allowed-origins}")
+	private String[] allowedOrigins;
+
+	@Override
+	public void registerStompEndpoints(StompEndpointRegistry registry) {
+		registry.addEndpoint("/ws")
+			.setAllowedOriginPatterns(allowedOrigins)
+			.withSockJS();
+	}
+
+	@Override
+	public void configureMessageBroker(MessageBrokerRegistry registry) {
+		registry.setApplicationDestinationPrefixes("/pub");
+		registry.enableSimpleBroker("/sub");
+	}
+}

--- a/src/main/java/one/colla/global/config/security/SecurityConfig.java
+++ b/src/main/java/one/colla/global/config/security/SecurityConfig.java
@@ -72,6 +72,7 @@ public class SecurityConfig {
 		AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auth) {
 		return auth.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
 			.requestMatchers(HttpMethod.OPTIONS, "*").permitAll()
+			.requestMatchers("/ws-stomp/**").permitAll()
 			.requestMatchers(PUBLIC_ENDPOINTS).permitAll()
 			.requestMatchers(HttpMethod.GET, CONDITIONAL_AUTHENTICATION_GET_ENDPOINTS).permitAll()
 			.requestMatchers(ANONYMOUS_ENDPOINTS).anonymous();

--- a/src/main/java/one/colla/global/exception/ExceptionCode.java
+++ b/src/main/java/one/colla/global/exception/ExceptionCode.java
@@ -39,6 +39,7 @@ public enum ExceptionCode {
 
 	/* 405xx CHAT */
 	NOT_FOUND_CHAT_CHANNEL(HttpStatus.NOT_FOUND, 40501, "해당 채팅 채널을 찾을 수 없습니다."),
+	NOT_FOUND_CHAT_CHANNEL_MESSAGE(HttpStatus.NOT_FOUND, 40502, "선택하신 채팅 채널에서 해당 메시지를 찾을 수 없습니다."),
 
 	/* 499xx ETC */
 	NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, 49901, "해당 경로를 찾을 수 없습니다."),

--- a/src/main/java/one/colla/global/exception/ExceptionCode.java
+++ b/src/main/java/one/colla/global/exception/ExceptionCode.java
@@ -37,6 +37,9 @@ public enum ExceptionCode {
 	FORBIDDEN_TEAMSPACE(HttpStatus.FORBIDDEN, 40307, "접근 권한이 없거나 존재하지 않는 팀 스페이스입니다."),
 	ALREADY_PARTICIPATED(HttpStatus.CONFLICT, 40308, "이미 참가한 사용자입니다."),
 
+	/* 405xx CHAT */
+	NOT_FOUND_CHAT_CHANNEL(HttpStatus.NOT_FOUND, 40501, "해당 채팅 채널을 찾을 수 없습니다."),
+
 	/* 499xx ETC */
 	NOT_FOUND_RESOURCE(HttpStatus.NOT_FOUND, 49901, "해당 경로를 찾을 수 없습니다."),
 	METHOD_FORBIDDEN(HttpStatus.METHOD_NOT_ALLOWED, 49902, "지원하지 않는 HTTP 메서드를 사용합니다."),

--- a/src/main/java/one/colla/global/handler/WebSocketExceptionHandler.java
+++ b/src/main/java/one/colla/global/handler/WebSocketExceptionHandler.java
@@ -1,0 +1,48 @@
+package one.colla.global.handler;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException;
+import org.springframework.messaging.simp.annotation.SendToUser;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+import one.colla.global.exception.CommonException;
+
+@Slf4j
+@ControllerAdvice
+public class WebSocketExceptionHandler {
+
+	@MessageExceptionHandler(MethodArgumentNotValidException.class)
+	@SendToUser("/queue/errors")
+	public Map<String, String> handleValidationException(MethodArgumentNotValidException ex) {
+		Map<String, String> errors = new HashMap<>();
+		if (ex.getBindingResult() != null) {
+			ex.getBindingResult().getAllErrors().forEach(error -> {
+				String fieldName = ((FieldError)error).getField();
+				String errorMessage = error.getDefaultMessage();
+				errors.put(fieldName, errorMessage);
+			});
+		}
+
+		log.error("WebSocket ValidationException 발생: {}", errors);
+		return errors;
+	}
+
+	@MessageExceptionHandler(CommonException.class)
+	@SendToUser("/queue/errors")
+	public String handleCommonException(CommonException ex) {
+		log.error("WebSocket CommonException 발생: {}", ex.getMessage(), ex);
+		return ex.getMessage();
+	}
+
+	@MessageExceptionHandler(Exception.class)
+	@SendToUser("/queue/errors")
+	public String handleException(Exception ex) {
+		log.error("Unexpected WebSocket error 발생: {}", ex.getMessage(), ex);
+		return "Unexpected error occurred";
+	}
+}

--- a/src/main/java/one/colla/teamspace/application/TeamspaceService.java
+++ b/src/main/java/one/colla/teamspace/application/TeamspaceService.java
@@ -309,5 +309,10 @@ public class TeamspaceService {
 	private boolean isParticipatedUser(@Nullable User user, Teamspace teamspace) {
 		return user != null && userTeamspaceRepository.existsByUserAndTeamspace(user, teamspace);
 	}
+
+	public Teamspace getTeamspace(Long teamspaceId) {
+		return teamspaceRepository.findById(teamspaceId)
+			.orElseThrow(() -> new CommonException(ExceptionCode.FORBIDDEN_TEAMSPACE));
+	}
 }
 

--- a/src/main/java/one/colla/teamspace/application/TeamspaceService.java
+++ b/src/main/java/one/colla/teamspace/application/TeamspaceService.java
@@ -309,10 +309,5 @@ public class TeamspaceService {
 	private boolean isParticipatedUser(@Nullable User user, Teamspace teamspace) {
 		return user != null && userTeamspaceRepository.existsByUserAndTeamspace(user, teamspace);
 	}
-
-	public Teamspace getTeamspace(Long teamspaceId) {
-		return teamspaceRepository.findById(teamspaceId)
-			.orElseThrow(() -> new CommonException(ExceptionCode.FORBIDDEN_TEAMSPACE));
-	}
 }
 

--- a/src/main/java/one/colla/teamspace/domain/Teamspace.java
+++ b/src/main/java/one/colla/teamspace/domain/Teamspace.java
@@ -95,4 +95,8 @@ public class Teamspace extends BaseEntity {
 	public void addChatChannel(ChatChannel chatChannel) {
 		chatChannels.add(chatChannel);
 	}
+
+	public void removeChatChannel(ChatChannel chatChannel) {
+		this.chatChannels.remove(chatChannel);
+	}
 }

--- a/src/main/java/one/colla/teamspace/domain/Teamspace.java
+++ b/src/main/java/one/colla/teamspace/domain/Teamspace.java
@@ -91,4 +91,8 @@ public class Teamspace extends BaseEntity {
 	public void deleteProfileImageUrl() {
 		this.teamspaceProfileImageUrl = null;
 	}
+
+	public void addChatChannel(ChatChannel chatChannel) {
+		chatChannels.add(chatChannel);
+	}
 }

--- a/src/main/java/one/colla/user/domain/User.java
+++ b/src/main/java/one/colla/user/domain/User.java
@@ -18,7 +18,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import one.colla.chat.domain.ChatChannelMessage;
-import one.colla.chat.domain.UserChatChannel;
 import one.colla.common.domain.BaseEntity;
 import one.colla.feed.collect.domain.CollectFeedResponse;
 import one.colla.feed.common.domain.Comment;
@@ -100,9 +99,6 @@ public class User extends BaseEntity {
 
 	@OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
 	private final List<UserTeamspace> userTeamspaces = new ArrayList<>();
-
-	@OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
-	private final List<UserChatChannel> userChatChannels = new ArrayList<>();
 
 	@OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
 	private final List<ChatChannelMessage> chatChannelMessages = new ArrayList<>();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,6 +65,10 @@ spring:
       token-uri: https://nid.naver.com/oauth2.0/token
       redirect-uri: ${NAVER_REDIRECT_URI}
 
+  websocket:
+    allowed-origins: http://localhost:8080, http://localhost:3000, ${BASE_URL}
+
+
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
@@ -93,6 +97,8 @@ cloud:
       static: ${AWS_SECRET_REGION_STATIC}
     stack:
       auto: false
+
+
 
 ---
 spring:
@@ -159,6 +165,8 @@ spring:
       scopes: ${NAVER_SCOPE}
       token-uri: https://nid.naver.com/oauth2.0/token
       redirect-uri: ${NAVER_REDIRECT_URI}
+  websocket:
+    allowed-origins: http://localhost:8080, http://localhost:3000, ${BASE_URL}
 
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8

--- a/src/test/java/one/colla/chat/application/ChatChannelServiceTest.java
+++ b/src/test/java/one/colla/chat/application/ChatChannelServiceTest.java
@@ -1,0 +1,100 @@
+package one.colla.chat.application;
+
+import static one.colla.common.fixtures.TeamspaceFixtures.*;
+import static one.colla.common.fixtures.UserFixtures.*;
+import static one.colla.common.fixtures.UserTeamspaceFixtures.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Optional;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import one.colla.chat.application.dto.request.CreateChatChannelRequest;
+import one.colla.chat.application.dto.response.CreateChatChannelResponse;
+import one.colla.chat.domain.ChatChannel;
+import one.colla.chat.domain.ChatChannelRepository;
+import one.colla.chat.domain.UserChatChannelRepository;
+import one.colla.common.ServiceTest;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.global.exception.CommonException;
+import one.colla.global.exception.ExceptionCode;
+import one.colla.teamspace.application.TeamspaceService;
+import one.colla.teamspace.domain.Teamspace;
+import one.colla.user.domain.User;
+
+class ChatChannelServiceTest extends ServiceTest {
+
+	@Autowired
+	private TeamspaceService teamspaceService;
+
+	@Autowired
+	private ChatChannelRepository chatChannelRepository;
+
+	@Autowired
+	private UserChatChannelRepository userChatChannelRepository;
+
+	@Autowired
+	private ChatChannelService chatChannelService;
+
+	@Nested
+	@DisplayName("채팅 채널 생성시")
+	class CreateChatChannelTest {
+
+		User USER1;
+		User USER2;
+		CustomUserDetails USER1_DETAILS;
+		Teamspace OS_TEAMSPACE;
+		CreateChatChannelRequest request;
+		CreateChatChannelResponse response;
+
+		@BeforeEach
+		void setUp() {
+			USER1 = testFixtureBuilder.buildUser(USER1());
+			USER2 = testFixtureBuilder.buildUser(USER2());
+			USER1_DETAILS = createCustomUserDetailsByUser(USER1);
+			OS_TEAMSPACE = testFixtureBuilder.buildTeamspace(OS_TEAMSPACE());
+			request = new CreateChatChannelRequest("새로운 채팅 채널");
+
+		}
+
+		@Test
+		@DisplayName("생성에 성공한다.")
+		void createChatChannel_Success() {
+			// given
+			testFixtureBuilder.buildUserTeamspace(MEMBER_USERTEAMSPACE(USER1, OS_TEAMSPACE));
+			testFixtureBuilder.buildUserTeamspace(MEMBER_USERTEAMSPACE(USER2, OS_TEAMSPACE));
+
+			// when
+			response = chatChannelService.createChatChannel(USER1_DETAILS, OS_TEAMSPACE.getId(), request);
+
+			// then
+			final Optional<ChatChannel> savedChatChannel = chatChannelRepository.findById(response.chatChannelId());
+
+			SoftAssertions.assertSoftly(softly -> {
+				softly.assertThat(savedChatChannel).hasValueSatisfying((chatChannel) -> {
+					assertThat(response.chatChannelId()).isEqualTo(chatChannel.getId());
+					assertThat(chatChannel.getUserChatChannels()).hasSize(2);
+				});
+
+			});
+		}
+
+		@Test
+		@DisplayName("팀스페이스에 참여하고 있지 않은 사용자면 예외가 발생한다.")
+		void createChatChannel_Fail() {
+			// given
+
+			// when & then
+			assertThatThrownBy(() -> chatChannelService.createChatChannel(USER1_DETAILS, OS_TEAMSPACE.getId(), request))
+				.isExactlyInstanceOf(CommonException.class)
+				.hasMessageContaining(ExceptionCode.FORBIDDEN_TEAMSPACE.getMessage());
+
+		}
+	}
+
+}

--- a/src/test/java/one/colla/chat/application/ChatChannelServiceTest.java
+++ b/src/test/java/one/colla/chat/application/ChatChannelServiceTest.java
@@ -1,5 +1,7 @@
 package one.colla.chat.application;
 
+import static one.colla.common.fixtures.ChatChannelFixtures.*;
+import static one.colla.common.fixtures.ChatChannelMessageFixtures.*;
 import static one.colla.common.fixtures.TeamspaceFixtures.*;
 import static one.colla.common.fixtures.UserFixtures.*;
 import static one.colla.common.fixtures.UserTeamspaceFixtures.*;
@@ -15,9 +17,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import one.colla.chat.application.dto.request.CreateChatChannelRequest;
+import one.colla.chat.application.dto.response.ChatChannelsResponse;
 import one.colla.chat.application.dto.response.CreateChatChannelResponse;
 import one.colla.chat.domain.ChatChannel;
+import one.colla.chat.domain.ChatChannelMessage;
 import one.colla.chat.domain.ChatChannelRepository;
+import one.colla.chat.domain.ChatType;
 import one.colla.chat.domain.UserChatChannelRepository;
 import one.colla.common.ServiceTest;
 import one.colla.common.security.authentication.CustomUserDetails;
@@ -25,6 +30,7 @@ import one.colla.global.exception.CommonException;
 import one.colla.global.exception.ExceptionCode;
 import one.colla.teamspace.application.TeamspaceService;
 import one.colla.teamspace.domain.Teamspace;
+import one.colla.teamspace.domain.UserTeamspace;
 import one.colla.user.domain.User;
 
 class ChatChannelServiceTest extends ServiceTest {
@@ -41,33 +47,37 @@ class ChatChannelServiceTest extends ServiceTest {
 	@Autowired
 	private ChatChannelService chatChannelService;
 
+	User USER1;
+	User USER2;
+	CustomUserDetails USER1_DETAILS;
+	Teamspace OS_TEAMSPACE;
+	UserTeamspace USER1_OS_USERTEAMSPACE;
+	UserTeamspace USER2_OS_USERTEAMSPACE;
+
+	@BeforeEach
+	void setUp() {
+		USER1 = testFixtureBuilder.buildUser(USER1());
+		USER2 = testFixtureBuilder.buildUser(USER2());
+		USER1_DETAILS = createCustomUserDetailsByUser(USER1);
+		OS_TEAMSPACE = testFixtureBuilder.buildTeamspace(OS_TEAMSPACE());
+	}
+
 	@Nested
 	@DisplayName("채팅 채널 생성시")
 	class CreateChatChannelTest {
 
-		User USER1;
-		User USER2;
-		CustomUserDetails USER1_DETAILS;
-		Teamspace OS_TEAMSPACE;
 		CreateChatChannelRequest request;
 		CreateChatChannelResponse response;
-
-		@BeforeEach
-		void setUp() {
-			USER1 = testFixtureBuilder.buildUser(USER1());
-			USER2 = testFixtureBuilder.buildUser(USER2());
-			USER1_DETAILS = createCustomUserDetailsByUser(USER1);
-			OS_TEAMSPACE = testFixtureBuilder.buildTeamspace(OS_TEAMSPACE());
-			request = new CreateChatChannelRequest("새로운 채팅 채널");
-
-		}
 
 		@Test
 		@DisplayName("생성에 성공한다.")
 		void createChatChannel_Success() {
+
 			// given
-			testFixtureBuilder.buildUserTeamspace(MEMBER_USERTEAMSPACE(USER1, OS_TEAMSPACE));
-			testFixtureBuilder.buildUserTeamspace(MEMBER_USERTEAMSPACE(USER2, OS_TEAMSPACE));
+			USER1_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(LEADER_USERTEAMSPACE(USER1, OS_TEAMSPACE));
+			USER2_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(MEMBER_USERTEAMSPACE(USER2, OS_TEAMSPACE));
+
+			request = new CreateChatChannelRequest("새로운 채팅 채널");
 
 			// when
 			response = chatChannelService.createChatChannel(USER1_DETAILS, OS_TEAMSPACE.getId(), request);
@@ -95,6 +105,97 @@ class ChatChannelServiceTest extends ServiceTest {
 				.hasMessageContaining(ExceptionCode.FORBIDDEN_TEAMSPACE.getMessage());
 
 		}
+	}
+
+	@Nested
+	@DisplayName("채팅 채널 조회시")
+	class GetChatChannelTest {
+
+		ChatChannel FRONTEND_CHAT_CHANNEL;
+		ChatChannel BACKEND_CHAT_CHANNEL;
+
+		ChatChannelMessage CHAT_MESSAGE1;
+
+		@Test
+		@DisplayName("조회에 성공한다.")
+		void getChatChannel_Success() {
+
+			// given
+			/* 팀스페이스 유저 참여 */
+			USER1_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(LEADER_USERTEAMSPACE(USER1, OS_TEAMSPACE));
+			USER2_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(MEMBER_USERTEAMSPACE(USER2, OS_TEAMSPACE));
+
+			/* 채팅 채널 생성 */
+			FRONTEND_CHAT_CHANNEL = testFixtureBuilder.buildChatChannel(FRONTEND_CHAT_CHANNEL(OS_TEAMSPACE));
+			BACKEND_CHAT_CHANNEL = testFixtureBuilder.buildChatChannel(BACKEND_CHAT_CHANNEL(OS_TEAMSPACE));
+
+			/* 팀스페이스에 채팅 채널 추가 */
+			OS_TEAMSPACE.addChatChannel(FRONTEND_CHAT_CHANNEL);
+			OS_TEAMSPACE.addChatChannel(BACKEND_CHAT_CHANNEL);
+
+			/* 채팅 채널 유저 참가 */
+			testFixtureBuilder.buildUserChatChannel(
+				FRONTEND_CHAT_CHANNEL.participateAllTeamspaceUser(OS_TEAMSPACE.getUserTeamspaces()));
+
+			testFixtureBuilder.buildUserChatChannel(
+				BACKEND_CHAT_CHANNEL.participateAllTeamspaceUser(OS_TEAMSPACE.getUserTeamspaces()));
+
+			/* 채팅 채널 메세지 생성 */
+			CHAT_MESSAGE1 = testFixtureBuilder.buildChatChannelMessage(CHAT_MESSAGE1(USER1, FRONTEND_CHAT_CHANNEL,
+				ChatType.TEXT));
+
+			/* 채팅채널에 last 메세지 업데이트 */
+			FRONTEND_CHAT_CHANNEL.updateLastChatMessage(CHAT_MESSAGE1.getId());
+
+			// when
+			ChatChannelsResponse response = chatChannelService.getChatChannels(USER1_DETAILS, OS_TEAMSPACE.getId());
+
+			//then
+
+			SoftAssertions.assertSoftly(softly -> {
+				softly.assertThat(response.chatChannels().size()).isEqualTo(2);
+				softly.assertThat(response.chatChannels().get(0).name())
+					.isEqualTo(FRONTEND_CHAT_CHANNEL.getChatChannelName().getValue());
+				softly.assertThat(response.chatChannels().get(0).lastChatMessage()).isEqualTo(
+					CHAT_MESSAGE1.getContent().getValue());
+				softly.assertThat(response.chatChannels().get(1).name())
+					.isEqualTo(BACKEND_CHAT_CHANNEL.getChatChannelName().getValue());
+				softly.assertThat(response.chatChannels().get(1).lastChatMessage()).isEqualTo(
+					null);
+
+			});
+
+		}
+
+		@Test
+		@DisplayName("팀스페이스 접근 권한이 없으면 예외가 발생한다.")
+		void getChatChannel_Fail() {
+
+			// given
+			// 팀스페이스 유저 참여 처리 X
+			FRONTEND_CHAT_CHANNEL = testFixtureBuilder.buildChatChannel(FRONTEND_CHAT_CHANNEL(OS_TEAMSPACE));
+			BACKEND_CHAT_CHANNEL = testFixtureBuilder.buildChatChannel(BACKEND_CHAT_CHANNEL(OS_TEAMSPACE));
+
+			testFixtureBuilder.buildUserChatChannel(
+				FRONTEND_CHAT_CHANNEL.participateAllTeamspaceUser(OS_TEAMSPACE.getUserTeamspaces()));
+			testFixtureBuilder.buildUserChatChannel(
+				BACKEND_CHAT_CHANNEL.participateAllTeamspaceUser(OS_TEAMSPACE.getUserTeamspaces()));
+
+			CHAT_MESSAGE1 = testFixtureBuilder.buildChatChannelMessage(CHAT_MESSAGE1(USER1, FRONTEND_CHAT_CHANNEL,
+				ChatType.TEXT));
+
+			OS_TEAMSPACE.addChatChannel(FRONTEND_CHAT_CHANNEL);
+			OS_TEAMSPACE.addChatChannel(BACKEND_CHAT_CHANNEL);
+
+			FRONTEND_CHAT_CHANNEL.updateLastChatMessage(CHAT_MESSAGE1.getId());
+
+			// when & then
+			assertThatThrownBy(() -> chatChannelService.getChatChannels(USER1_DETAILS, OS_TEAMSPACE.getId()))
+				.isExactlyInstanceOf(CommonException.class)
+				.hasMessageContaining(ExceptionCode.FORBIDDEN_TEAMSPACE.getMessage());
+
+		}
+
 	}
 
 }

--- a/src/test/java/one/colla/chat/application/ChatChannelServiceTest.java
+++ b/src/test/java/one/colla/chat/application/ChatChannelServiceTest.java
@@ -446,6 +446,7 @@ class ChatChannelServiceTest extends ServiceTest {
 			// then
 			SoftAssertions.assertSoftly(softly -> {
 				softly.assertThat(chatChannelRepository.findById(FRONTEND_CHAT_CHANNEL.getId())).isEmpty();
+				softly.assertThat(OS_TEAMSPACE.getChatChannels().contains(FRONTEND_CHAT_CHANNEL)).isEqualTo(false);
 				softly.assertThat(chatChannelMessageRepository.findChatChannelMessageByChatChannelAndCriteria(
 					FRONTEND_CHAT_CHANNEL, null, PageRequest.of(0, 50))).isEmpty();
 			});

--- a/src/test/java/one/colla/chat/application/ChatChannelServiceTest.java
+++ b/src/test/java/one/colla/chat/application/ChatChannelServiceTest.java
@@ -26,7 +26,6 @@ import one.colla.chat.application.dto.response.CreateChatChannelResponse;
 import one.colla.chat.domain.ChatChannel;
 import one.colla.chat.domain.ChatChannelMessage;
 import one.colla.chat.domain.ChatChannelRepository;
-import one.colla.chat.domain.ChatType;
 import one.colla.chat.domain.UserChatChannelRepository;
 import one.colla.common.ServiceTest;
 import one.colla.common.security.authentication.CustomUserDetails;
@@ -138,8 +137,8 @@ class ChatChannelServiceTest extends ServiceTest {
 				BACKEND_CHAT_CHANNEL.participateAllTeamspaceUser(OS_TEAMSPACE.getUserTeamspaces()));
 
 			/* 채팅 채널 메세지 생성 */
-			CHAT_MESSAGE1 = testFixtureBuilder.buildChatChannelMessage(CHAT_MESSAGE1(USER1, FRONTEND_CHAT_CHANNEL,
-				ChatType.TEXT));
+			CHAT_MESSAGE1 = testFixtureBuilder.buildChatChannelMessage(
+				CHAT_MESSAGE1(USER1, OS_TEAMSPACE, FRONTEND_CHAT_CHANNEL));
 
 			/* 채팅채널에 last 메세지 업데이트 */
 			FRONTEND_CHAT_CHANNEL.updateLastChatMessage(CHAT_MESSAGE1.getId());
@@ -280,7 +279,7 @@ class ChatChannelServiceTest extends ServiceTest {
 			List<ChatChannelMessage> messages = new ArrayList<>();
 			for (int i = 0; i < 100; i++) {
 				ChatChannelMessage msg = testFixtureBuilder.buildChatChannelMessage(
-					RANDOM_CHAT_MESSAGE(USER1, FRONTEND_CHAT_CHANNEL, ChatType.TEXT));
+					RANDOM_CHAT_MESSAGE(USER1, OS_TEAMSPACE, FRONTEND_CHAT_CHANNEL));
 				messages.add(msg);
 				FRONTEND_CHAT_CHANNEL.updateLastChatMessage(msg.getId());
 			}
@@ -305,7 +304,7 @@ class ChatChannelServiceTest extends ServiceTest {
 			List<ChatChannelMessage> messages = new ArrayList<>();
 			for (int i = 0; i < 100; i++) {
 				ChatChannelMessage msg = testFixtureBuilder.buildChatChannelMessage(
-					RANDOM_CHAT_MESSAGE(USER1, FRONTEND_CHAT_CHANNEL, ChatType.TEXT));
+					RANDOM_CHAT_MESSAGE(USER1, OS_TEAMSPACE, FRONTEND_CHAT_CHANNEL));
 				messages.add(msg);
 				FRONTEND_CHAT_CHANNEL.updateLastChatMessage(msg.getId());
 			}
@@ -331,7 +330,7 @@ class ChatChannelServiceTest extends ServiceTest {
 			List<ChatChannelMessage> messages = new ArrayList<>();
 			for (int i = 0; i < 100; i++) {
 				ChatChannelMessage msg = testFixtureBuilder.buildChatChannelMessage(
-					RANDOM_CHAT_MESSAGE(USER1, FRONTEND_CHAT_CHANNEL, ChatType.TEXT));
+					RANDOM_CHAT_MESSAGE(USER1, OS_TEAMSPACE, FRONTEND_CHAT_CHANNEL));
 				messages.add(msg);
 				FRONTEND_CHAT_CHANNEL.updateLastChatMessage(msg.getId());
 			}

--- a/src/test/java/one/colla/chat/application/ChatChannelServiceTest.java
+++ b/src/test/java/one/colla/chat/application/ChatChannelServiceTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import one.colla.chat.application.dto.request.CreateChatChannelRequest;
+import one.colla.chat.application.dto.request.UpdateChatChannelNameRequest;
 import one.colla.chat.application.dto.response.ChatChannelsResponse;
 import one.colla.chat.application.dto.response.CreateChatChannelResponse;
 import one.colla.chat.domain.ChatChannel;
@@ -60,6 +61,8 @@ class ChatChannelServiceTest extends ServiceTest {
 		USER2 = testFixtureBuilder.buildUser(USER2());
 		USER1_DETAILS = createCustomUserDetailsByUser(USER1);
 		OS_TEAMSPACE = testFixtureBuilder.buildTeamspace(OS_TEAMSPACE());
+		USER1_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(LEADER_USERTEAMSPACE(USER1, OS_TEAMSPACE));
+		USER2_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(MEMBER_USERTEAMSPACE(USER2, OS_TEAMSPACE));
 	}
 
 	@Nested
@@ -74,9 +77,6 @@ class ChatChannelServiceTest extends ServiceTest {
 		void createChatChannel_Success() {
 
 			// given
-			USER1_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(LEADER_USERTEAMSPACE(USER1, OS_TEAMSPACE));
-			USER2_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(MEMBER_USERTEAMSPACE(USER2, OS_TEAMSPACE));
-
 			request = new CreateChatChannelRequest("새로운 채팅 채널");
 
 			// when
@@ -98,9 +98,12 @@ class ChatChannelServiceTest extends ServiceTest {
 		@DisplayName("팀스페이스에 참여하고 있지 않은 사용자면 예외가 발생한다.")
 		void createChatChannel_Fail() {
 			// given
+			User OTHER_USER = testFixtureBuilder.buildUser(RANDOMUSER());
+			CustomUserDetails OTHER_USER_DETAILS = createCustomUserDetailsByUser(OTHER_USER);
 
 			// when & then
-			assertThatThrownBy(() -> chatChannelService.createChatChannel(USER1_DETAILS, OS_TEAMSPACE.getId(), request))
+			assertThatThrownBy(
+				() -> chatChannelService.createChatChannel(OTHER_USER_DETAILS, OS_TEAMSPACE.getId(), request))
 				.isExactlyInstanceOf(CommonException.class)
 				.hasMessageContaining(ExceptionCode.FORBIDDEN_TEAMSPACE.getMessage());
 
@@ -113,18 +116,10 @@ class ChatChannelServiceTest extends ServiceTest {
 
 		ChatChannel FRONTEND_CHAT_CHANNEL;
 		ChatChannel BACKEND_CHAT_CHANNEL;
-
 		ChatChannelMessage CHAT_MESSAGE1;
 
-		@Test
-		@DisplayName("조회에 성공한다.")
-		void getChatChannel_Success() {
-
-			// given
-			/* 팀스페이스 유저 참여 */
-			USER1_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(LEADER_USERTEAMSPACE(USER1, OS_TEAMSPACE));
-			USER2_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(MEMBER_USERTEAMSPACE(USER2, OS_TEAMSPACE));
-
+		@BeforeEach
+		void setUp() {
 			/* 채팅 채널 생성 */
 			FRONTEND_CHAT_CHANNEL = testFixtureBuilder.buildChatChannel(FRONTEND_CHAT_CHANNEL(OS_TEAMSPACE));
 			BACKEND_CHAT_CHANNEL = testFixtureBuilder.buildChatChannel(BACKEND_CHAT_CHANNEL(OS_TEAMSPACE));
@@ -136,7 +131,6 @@ class ChatChannelServiceTest extends ServiceTest {
 			/* 채팅 채널 유저 참가 */
 			testFixtureBuilder.buildUserChatChannel(
 				FRONTEND_CHAT_CHANNEL.participateAllTeamspaceUser(OS_TEAMSPACE.getUserTeamspaces()));
-
 			testFixtureBuilder.buildUserChatChannel(
 				BACKEND_CHAT_CHANNEL.participateAllTeamspaceUser(OS_TEAMSPACE.getUserTeamspaces()));
 
@@ -146,6 +140,11 @@ class ChatChannelServiceTest extends ServiceTest {
 
 			/* 채팅채널에 last 메세지 업데이트 */
 			FRONTEND_CHAT_CHANNEL.updateLastChatMessage(CHAT_MESSAGE1.getId());
+		}
+
+		@Test
+		@DisplayName("조회에 성공한다.")
+		void getChatChannel_Success() {
 
 			// when
 			ChatChannelsResponse response = chatChannelService.getChatChannels(USER1_DETAILS, OS_TEAMSPACE.getId());
@@ -172,30 +171,79 @@ class ChatChannelServiceTest extends ServiceTest {
 		void getChatChannel_Fail() {
 
 			// given
-			// 팀스페이스 유저 참여 처리 X
-			FRONTEND_CHAT_CHANNEL = testFixtureBuilder.buildChatChannel(FRONTEND_CHAT_CHANNEL(OS_TEAMSPACE));
-			BACKEND_CHAT_CHANNEL = testFixtureBuilder.buildChatChannel(BACKEND_CHAT_CHANNEL(OS_TEAMSPACE));
-
-			testFixtureBuilder.buildUserChatChannel(
-				FRONTEND_CHAT_CHANNEL.participateAllTeamspaceUser(OS_TEAMSPACE.getUserTeamspaces()));
-			testFixtureBuilder.buildUserChatChannel(
-				BACKEND_CHAT_CHANNEL.participateAllTeamspaceUser(OS_TEAMSPACE.getUserTeamspaces()));
-
-			CHAT_MESSAGE1 = testFixtureBuilder.buildChatChannelMessage(CHAT_MESSAGE1(USER1, FRONTEND_CHAT_CHANNEL,
-				ChatType.TEXT));
-
-			OS_TEAMSPACE.addChatChannel(FRONTEND_CHAT_CHANNEL);
-			OS_TEAMSPACE.addChatChannel(BACKEND_CHAT_CHANNEL);
-
-			FRONTEND_CHAT_CHANNEL.updateLastChatMessage(CHAT_MESSAGE1.getId());
+			User OTHER_USER = testFixtureBuilder.buildUser(RANDOMUSER());
+			CustomUserDetails OTHER_USER_DETAILS = createCustomUserDetailsByUser(OTHER_USER);
 
 			// when & then
-			assertThatThrownBy(() -> chatChannelService.getChatChannels(USER1_DETAILS, OS_TEAMSPACE.getId()))
+			assertThatThrownBy(() -> chatChannelService.getChatChannels(OTHER_USER_DETAILS, OS_TEAMSPACE.getId()))
 				.isExactlyInstanceOf(CommonException.class)
 				.hasMessageContaining(ExceptionCode.FORBIDDEN_TEAMSPACE.getMessage());
 
 		}
 
+	}
+
+	@Nested
+	@DisplayName("채팅 채널 이름 수정시")
+	class UpdateChatChannelNameTest {
+
+		UpdateChatChannelNameRequest request;
+		ChatChannel FRONTEND_CHAT_CHANNEL;
+		String NEW_CHAT_CHANNEL_NAME = "새로운 채팅 채널 이름";
+
+		@BeforeEach
+		void setUp() {
+			FRONTEND_CHAT_CHANNEL = testFixtureBuilder.buildChatChannel(FRONTEND_CHAT_CHANNEL(OS_TEAMSPACE));
+			OS_TEAMSPACE.addChatChannel(FRONTEND_CHAT_CHANNEL);
+		}
+
+		@Test
+		@DisplayName("수정에 성공한다.")
+		void updateChatChannelName_Success() {
+			// given
+			request = new UpdateChatChannelNameRequest(FRONTEND_CHAT_CHANNEL.getId(), NEW_CHAT_CHANNEL_NAME);
+
+			// when
+			chatChannelService.updateChatChannelName(USER1_DETAILS, OS_TEAMSPACE.getId(), request);
+
+			// then
+			final Optional<ChatChannel> updatedChatChannel = chatChannelRepository.findById(
+				FRONTEND_CHAT_CHANNEL.getId());
+
+			SoftAssertions.assertSoftly(softly -> {
+				softly.assertThat(updatedChatChannel).hasValueSatisfying(chatChannel -> {
+					assertThat(chatChannel.getChatChannelName().getValue()).isEqualTo(NEW_CHAT_CHANNEL_NAME);
+				});
+			});
+		}
+
+		@Test
+		@DisplayName("팀스페이스 접근 권한이 없으면 예외가 발생한다.")
+		void updateChatChannelName_Fail_NoAccess() {
+			// given
+			User OTHER_USER = testFixtureBuilder.buildUser(RANDOMUSER());
+			CustomUserDetails OTHER_USER_DETAILS = createCustomUserDetailsByUser(OTHER_USER);
+			request = new UpdateChatChannelNameRequest(FRONTEND_CHAT_CHANNEL.getId(), NEW_CHAT_CHANNEL_NAME);
+
+			// when & then
+			assertThatThrownBy(
+				() -> chatChannelService.updateChatChannelName(OTHER_USER_DETAILS, OS_TEAMSPACE.getId(), request))
+				.isExactlyInstanceOf(CommonException.class)
+				.hasMessageContaining(ExceptionCode.FORBIDDEN_TEAMSPACE.getMessage());
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 채팅 채널이면 예외가 발생한다.")
+		void updateChatChannelName_Fail_NotFound() {
+			// given
+			request = new UpdateChatChannelNameRequest(999L, NEW_CHAT_CHANNEL_NAME);
+
+			// when & then
+			assertThatThrownBy(
+				() -> chatChannelService.updateChatChannelName(USER1_DETAILS, OS_TEAMSPACE.getId(), request))
+				.isExactlyInstanceOf(CommonException.class)
+				.hasMessageContaining(ExceptionCode.NOT_FOUND_CHAT_CHANNEL.getMessage());
+		}
 	}
 
 }

--- a/src/test/java/one/colla/chat/application/ChatWebSocketServiceTest.java
+++ b/src/test/java/one/colla/chat/application/ChatWebSocketServiceTest.java
@@ -1,0 +1,14 @@
+package one.colla.chat.application;
+
+import org.junit.jupiter.api.Test;
+
+import one.colla.common.ServiceTest;
+
+class ChatWebSocketServiceTest extends ServiceTest {
+	// TODO: 테스트 작성 필요
+
+	@Test
+	void processMessage() {
+	}
+
+}

--- a/src/test/java/one/colla/chat/application/ChatWebSocketServiceTest.java
+++ b/src/test/java/one/colla/chat/application/ChatWebSocketServiceTest.java
@@ -1,14 +1,212 @@
 package one.colla.chat.application;
 
-import org.junit.jupiter.api.Test;
+import static one.colla.common.fixtures.ChatChannelFixtures.*;
+import static one.colla.common.fixtures.TeamspaceFixtures.*;
+import static one.colla.common.fixtures.UserFixtures.*;
+import static one.colla.common.fixtures.UserTeamspaceFixtures.*;
+import static org.assertj.core.api.AssertionsForClassTypes.*;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import one.colla.chat.application.dto.request.ChatCreateRequest;
+import one.colla.chat.application.dto.response.ChatChannelMessageResponse;
+import one.colla.chat.domain.ChatChannel;
+import one.colla.chat.domain.ChatChannelMessage;
+import one.colla.chat.domain.ChatChannelMessageRepository;
+import one.colla.chat.domain.ChatType;
 import one.colla.common.ServiceTest;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.global.exception.CommonException;
+import one.colla.global.exception.ExceptionCode;
+import one.colla.teamspace.application.TeamspaceService;
+import one.colla.teamspace.domain.Teamspace;
+import one.colla.teamspace.domain.UserTeamspace;
+import one.colla.user.domain.User;
+import one.colla.user.domain.UserRepository;
 
 class ChatWebSocketServiceTest extends ServiceTest {
-	// TODO: 테스트 작성 필요
 
-	@Test
-	void processMessage() {
+	@Autowired
+	private TeamspaceService teamspaceService;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private ChatChannelMessageRepository chatChannelMessageRepository;
+
+	@Autowired
+	private ChatWebSocketService chatWebSocketService;
+
+	User USER1;
+	User USER2;
+	CustomUserDetails USER1_DETAILS;
+	Teamspace OS_TEAMSPACE;
+	UserTeamspace USER1_OS_USERTEAMSPACE;
+	UserTeamspace USER2_OS_USERTEAMSPACE;
+	ChatChannel FRONTEND_CHAT_CHANNEL;
+	ChatChannel BACKEND_CHAT_CHANNEL;
+
+	@BeforeEach
+	void setUp() {
+		USER1 = testFixtureBuilder.buildUser(USER1());
+		USER2 = testFixtureBuilder.buildUser(USER2());
+		USER1_DETAILS = createCustomUserDetailsByUser(USER1);
+
+		OS_TEAMSPACE = testFixtureBuilder.buildTeamspace(OS_TEAMSPACE());
+		USER1_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(LEADER_USERTEAMSPACE(USER1, OS_TEAMSPACE));
+		USER2_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(MEMBER_USERTEAMSPACE(USER2, OS_TEAMSPACE));
+
+		FRONTEND_CHAT_CHANNEL = testFixtureBuilder.buildChatChannel(FRONTEND_CHAT_CHANNEL(OS_TEAMSPACE));
+		BACKEND_CHAT_CHANNEL = testFixtureBuilder.buildChatChannel(BACKEND_CHAT_CHANNEL(OS_TEAMSPACE));
+
+		OS_TEAMSPACE.addChatChannel(FRONTEND_CHAT_CHANNEL);
+		OS_TEAMSPACE.addChatChannel(BACKEND_CHAT_CHANNEL);
+
+		testFixtureBuilder.buildUserChatChannel(
+			FRONTEND_CHAT_CHANNEL.participateAllTeamspaceUser(OS_TEAMSPACE.getUserTeamspaces()));
+		testFixtureBuilder.buildUserChatChannel(
+			BACKEND_CHAT_CHANNEL.participateAllTeamspaceUser(OS_TEAMSPACE.getUserTeamspaces()));
 	}
 
+	@Nested
+	@DisplayName("채팅 메시지 생성시")
+	class ProcessMessageTest {
+
+		ChatCreateRequest request = new ChatCreateRequest(ChatType.TEXT, "채팅 메시지 생성 요청", null, null);
+
+		@Test
+		@DisplayName("텍스트 메시지 생성에 성공한다.")
+		void processTextMessage_Success() {
+			// given
+			ChatCreateRequest request = new ChatCreateRequest(ChatType.TEXT, "텍스트 메시지", null, null);
+
+			// when
+			ChatChannelMessageResponse response = chatWebSocketService.processMessage(
+				request, USER1.getId(), OS_TEAMSPACE.getId(), FRONTEND_CHAT_CHANNEL.getId());
+
+			// then
+			SoftAssertions.assertSoftly(softly -> {
+				softly.assertThat(response).isNotNull();
+				softly.assertThat(response.content()).isEqualTo(request.content());
+				softly.assertThat(response.chatChannelId()).isEqualTo(FRONTEND_CHAT_CHANNEL.getId());
+				softly.assertThat(response.author().id()).isEqualTo(USER1.getId());
+			});
+
+			Optional<ChatChannelMessage> savedMessage = chatChannelMessageRepository.findById(response.id());
+			assertThat(savedMessage).isPresent();
+		}
+
+		@Test
+		@DisplayName("이미지 메시지 생성에 성공한다.")
+		void processImageMessage_Success() {
+			// given
+			final String FILE1_NAME = "image1.jpg";
+			final String FILE2_NAME = "image2.jpg";
+
+			final String FILE1_URL = "https://cdn.colla.so/image1.jpg";
+			final String FILE2_URL = "https://cdn.colla.so/image2.jpg";
+
+			List<ChatCreateRequest.FileDto> images = List.of(
+				new ChatCreateRequest.FileDto(FILE1_NAME, FILE1_URL, 1024L),
+				new ChatCreateRequest.FileDto(FILE2_NAME, FILE2_URL, 2048L)
+			);
+			ChatCreateRequest request = new ChatCreateRequest(ChatType.IMAGE, null, images, null);
+
+			// when
+			ChatChannelMessageResponse response = chatWebSocketService.processMessage(
+				request, USER1.getId(), OS_TEAMSPACE.getId(), FRONTEND_CHAT_CHANNEL.getId());
+
+			// then
+			SoftAssertions.assertSoftly(softly -> {
+				softly.assertThat(response).isNotNull();
+				softly.assertThat(response.chatChannelId()).isEqualTo(FRONTEND_CHAT_CHANNEL.getId());
+				softly.assertThat(response.author().id()).isEqualTo(USER1.getId());
+				softly.assertThat(response.attachments()).hasSize(2);
+				softly.assertThat(response.attachments().get(0).filename()).isEqualTo(FILE1_NAME);
+				softly.assertThat(response.attachments().get(1).filename()).isEqualTo(FILE2_NAME);
+			});
+
+			Optional<ChatChannelMessage> savedMessage = chatChannelMessageRepository.findById(response.id());
+			assertThat(savedMessage).isPresent();
+		}
+
+		@Test
+		@DisplayName("파일 메시지 생성에 성공한다.")
+		void processFileMessage_Success() {
+			// given
+			final String ATTACHMENT1_NAME = "image1.jpg";
+			final String ATTACHMENT2_NAME = "image2.jpg";
+
+			final String ATTACHMENT1_URL = "https://cdn.colla.so/image1.jpg";
+			final String ATTACHMENT2_URL = "https://cdn.colla.so/image2.jpg";
+
+			List<ChatCreateRequest.FileDto> attachments = List.of(
+				new ChatCreateRequest.FileDto(ATTACHMENT1_NAME, ATTACHMENT1_URL, 5120L),
+				new ChatCreateRequest.FileDto(ATTACHMENT2_NAME, ATTACHMENT2_URL, 10240L)
+			);
+			ChatCreateRequest request = new ChatCreateRequest(ChatType.FILE, null, null, attachments);
+
+			// when
+			ChatChannelMessageResponse response = chatWebSocketService.processMessage(
+				request, USER1.getId(), OS_TEAMSPACE.getId(), FRONTEND_CHAT_CHANNEL.getId());
+
+			// then
+			SoftAssertions.assertSoftly(softly -> {
+				softly.assertThat(response).isNotNull();
+				softly.assertThat(response.chatChannelId()).isEqualTo(FRONTEND_CHAT_CHANNEL.getId());
+				softly.assertThat(response.author().id()).isEqualTo(USER1.getId());
+				softly.assertThat(response.attachments()).hasSize(2);
+				softly.assertThat(response.attachments().get(0).filename()).isEqualTo(ATTACHMENT1_NAME);
+				softly.assertThat(response.attachments().get(1).filename()).isEqualTo(ATTACHMENT2_NAME);
+			});
+
+			Optional<ChatChannelMessage> savedMessage = chatChannelMessageRepository.findById(response.id());
+			assertThat(savedMessage).isPresent();
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 유저로 메시지 생성 시도시 예외가 발생한다.")
+		void processMessage_Fail_UserNotFound() {
+
+			// when & then
+			assertThatThrownBy(() -> chatWebSocketService.processMessage(
+				request, 999L, OS_TEAMSPACE.getId(), FRONTEND_CHAT_CHANNEL.getId()))
+				.isExactlyInstanceOf(CommonException.class)
+				.hasMessageContaining(ExceptionCode.NOT_FOUND_USER.getMessage());
+		}
+
+		@Test
+		@DisplayName("팀스페이스에 참여하지 않은 유저가 메시지 생성 시도시 예외가 발생한다.")
+		void processMessage_Fail_UserNotInTeamspace() {
+			// given
+			User OTHER_USER = testFixtureBuilder.buildUser(RANDOMUSER());
+
+			// when & then
+			assertThatThrownBy(
+				() -> chatWebSocketService.processMessage(
+					request, OTHER_USER.getId(), OS_TEAMSPACE.getId(), FRONTEND_CHAT_CHANNEL.getId()))
+				.isExactlyInstanceOf(CommonException.class)
+				.hasMessageContaining(ExceptionCode.FORBIDDEN_TEAMSPACE.getMessage());
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 채널로 메시지 생성 시도시 예외가 발생한다.")
+		void processMessage_Fail_ChannelNotFound() {
+
+			// when & then
+			assertThatThrownBy(
+				() -> chatWebSocketService.processMessage(request, USER1.getId(), OS_TEAMSPACE.getId(), 999L))
+				.isExactlyInstanceOf(CommonException.class)
+				.hasMessageContaining(ExceptionCode.NOT_FOUND_CHAT_CHANNEL.getMessage());
+		}
+	}
 }

--- a/src/test/java/one/colla/chat/domain/ChatChannelMessageRepositoryTest.java
+++ b/src/test/java/one/colla/chat/domain/ChatChannelMessageRepositoryTest.java
@@ -81,7 +81,7 @@ class ChatChannelMessageRepositoryTest extends RepositoryTest {
 		List<ChatChannelMessage> messages = new ArrayList<>();
 		for (int i = 0; i < 10; i++) {
 			ChatChannelMessage message = chatChannelMessageRepository.save(
-				RANDOM_CHAT_MESSAGE(USER1, FRONTEND_CHAT_CHANNEL, ChatType.TEXT));
+				RANDOM_CHAT_MESSAGE(USER1, OS_TEAMSPACE, FRONTEND_CHAT_CHANNEL));
 			messages.add(message);
 		}
 
@@ -104,7 +104,7 @@ class ChatChannelMessageRepositoryTest extends RepositoryTest {
 		List<ChatChannelMessage> messages = new ArrayList<>();
 		for (int i = 0; i < 10; i++) {
 			ChatChannelMessage message = chatChannelMessageRepository.save(
-				RANDOM_CHAT_MESSAGE(USER1, FRONTEND_CHAT_CHANNEL, ChatType.TEXT));
+				RANDOM_CHAT_MESSAGE(USER1, OS_TEAMSPACE, FRONTEND_CHAT_CHANNEL));
 			messages.add(message);
 		}
 

--- a/src/test/java/one/colla/chat/domain/ChatChannelMessageRepositoryTest.java
+++ b/src/test/java/one/colla/chat/domain/ChatChannelMessageRepositoryTest.java
@@ -1,0 +1,125 @@
+package one.colla.chat.domain;
+
+import static one.colla.common.fixtures.ChatChannelFixtures.*;
+import static one.colla.common.fixtures.ChatChannelMessageFixtures.*;
+import static one.colla.common.fixtures.TeamspaceFixtures.*;
+import static one.colla.common.fixtures.UserFixtures.*;
+import static one.colla.common.fixtures.UserTeamspaceFixtures.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import one.colla.common.RepositoryTest;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.teamspace.domain.Teamspace;
+import one.colla.teamspace.domain.TeamspaceRepository;
+import one.colla.teamspace.domain.UserTeamspace;
+import one.colla.user.domain.User;
+import one.colla.user.domain.UserRepository;
+
+class ChatChannelMessageRepositoryTest extends RepositoryTest {
+
+	@Autowired
+	private ChatChannelMessageRepository chatChannelMessageRepository;
+
+	@Autowired
+	private ChatChannelRepository chatChannelRepository;
+
+	@Autowired
+	private TeamspaceRepository teamspaceRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	User USER1;
+	User USER2;
+	CustomUserDetails USER1_DETAILS;
+	Teamspace OS_TEAMSPACE;
+	UserTeamspace USER1_OS_USERTEAMSPACE;
+	UserTeamspace USER2_OS_USERTEAMSPACE;
+	ChatChannel FRONTEND_CHAT_CHANNEL;
+	ChatChannel BACKEND_CHAT_CHANNEL;
+
+	@BeforeEach
+	void setUp() {
+		USER1 = testFixtureBuilder.buildUser(USER1());
+		USER2 = testFixtureBuilder.buildUser(USER2());
+		USER1_DETAILS = createCustomUserDetailsByUser(USER1);
+
+		/* 팀스페이스 생성 & 참가 */
+		OS_TEAMSPACE = testFixtureBuilder.buildTeamspace(OS_TEAMSPACE());
+		USER1_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(LEADER_USERTEAMSPACE(USER1, OS_TEAMSPACE));
+		USER2_OS_USERTEAMSPACE = testFixtureBuilder.buildUserTeamspace(MEMBER_USERTEAMSPACE(USER2, OS_TEAMSPACE));
+
+		/* 채팅 채널 생성 */
+		FRONTEND_CHAT_CHANNEL = testFixtureBuilder.buildChatChannel(FRONTEND_CHAT_CHANNEL(OS_TEAMSPACE));
+		BACKEND_CHAT_CHANNEL = testFixtureBuilder.buildChatChannel(BACKEND_CHAT_CHANNEL(OS_TEAMSPACE));
+
+		/* 팀스페이스에 채팅 채널 추가 */
+		OS_TEAMSPACE.addChatChannel(FRONTEND_CHAT_CHANNEL);
+		OS_TEAMSPACE.addChatChannel(BACKEND_CHAT_CHANNEL);
+
+		/* 채팅 채널 유저 참가 */
+		testFixtureBuilder.buildUserChatChannel(
+			FRONTEND_CHAT_CHANNEL.participateAllTeamspaceUser(OS_TEAMSPACE.getUserTeamspaces()));
+		testFixtureBuilder.buildUserChatChannel(
+			BACKEND_CHAT_CHANNEL.participateAllTeamspaceUser(OS_TEAMSPACE.getUserTeamspaces()));
+	}
+
+	@Test
+	@DisplayName("채팅 메시지를 생성 날짜 기준 내림차순으로 조회할 수 있다.")
+	void findChatChannelMessageByChatChannelAndCriteria_Success() {
+		// given
+		List<ChatChannelMessage> messages = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			ChatChannelMessage message = chatChannelMessageRepository.save(
+				RANDOM_CHAT_MESSAGE(USER1, FRONTEND_CHAT_CHANNEL, ChatType.TEXT));
+			messages.add(message);
+		}
+
+		Pageable pageable = PageRequest.of(0, 5);
+
+		// when
+		List<ChatChannelMessage> findMessages = chatChannelMessageRepository.findChatChannelMessageByChatChannelAndCriteria(
+			FRONTEND_CHAT_CHANNEL, null, pageable);
+
+		// then
+		assertThat(findMessages).hasSize(5);
+		assertThat(findMessages.get(0).getCreatedAt()).isAfterOrEqualTo(
+			findMessages.get(findMessages.size() - 1).getCreatedAt());
+	}
+
+	@Test
+	@DisplayName("before 파라미터를 사용하여 채팅 메시지를 필터링할 수 있다.")
+	void findChatChannelMessageByChatChannelAndCriteria_BeforeParameter() {
+		// given
+		List<ChatChannelMessage> messages = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			ChatChannelMessage message = chatChannelMessageRepository.save(
+				RANDOM_CHAT_MESSAGE(USER1, FRONTEND_CHAT_CHANNEL, ChatType.TEXT));
+			messages.add(message);
+		}
+
+		ChatChannelMessage beforeMessage = messages.get(4);
+
+		Pageable pageable = PageRequest.of(0, 5);
+
+		// when
+		List<ChatChannelMessage> findMessages = chatChannelMessageRepository.findChatChannelMessageByChatChannelAndCriteria(
+			FRONTEND_CHAT_CHANNEL, beforeMessage.getId(), pageable);
+
+		// then
+		assertThat(findMessages).hasSize(4);
+		assertThat(findMessages.get(0).getCreatedAt()).isBefore(beforeMessage.getCreatedAt());
+	}
+
+}
+

--- a/src/test/java/one/colla/chat/domain/vo/ChatChannelMessageContentTest.java
+++ b/src/test/java/one/colla/chat/domain/vo/ChatChannelMessageContentTest.java
@@ -1,0 +1,65 @@
+package one.colla.chat.domain.vo;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import one.colla.global.exception.VoException;
+
+class ChatChannelMessageContentTest {
+
+	@Test
+	@DisplayName("두 객체의 값이 같으면 같은 객체이다.")
+	void testEqualsAndHashCode1() {
+		// given
+		String input = "Hello, World!";
+
+		// when
+		ChatChannelMessageContent content1 = ChatChannelMessageContent.from(input);
+		ChatChannelMessageContent content2 = ChatChannelMessageContent.from(input);
+
+		// then
+		assertThat(content1).isEqualTo(content2);
+	}
+
+	@Test
+	@DisplayName("두 객체의 값이 다르면 다른 객체이다.")
+	void testEqualsAndHashCode2() {
+		// given
+		String input1 = "Hello, World!";
+		String input2 = "Different content";
+
+		// when
+		ChatChannelMessageContent content1 = ChatChannelMessageContent.from(input1);
+		ChatChannelMessageContent content2 = ChatChannelMessageContent.from(input2);
+
+		// then
+		assertThat(content1).isNotEqualTo(content2);
+	}
+
+	@Test
+	@DisplayName("유효한 채팅 메시지를 생성할 수 있다.")
+	void testValidChatChannelMessageContent() {
+		// given
+		String input = "Valid chat message";
+
+		// when
+		ChatChannelMessageContent content = ChatChannelMessageContent.from(input);
+
+		// then
+		assertThat(content.getValue()).isEqualTo(input);
+	}
+
+	@Test
+	@DisplayName("채팅 메시지 글자 수는 1024자 초과일 수 없다.")
+	void testChatChannelMessageContentTooLong() {
+		// given
+		String input = "A".repeat(1024 + 1);
+
+		// when & then
+		assertThatThrownBy(() -> ChatChannelMessageContent.from(input))
+			.isInstanceOf(VoException.class)
+			.hasMessage("채팅 메시지는 1024자 이하여야 합니다.");
+	}
+}

--- a/src/test/java/one/colla/chat/domain/vo/ChatChannelNameTest.java
+++ b/src/test/java/one/colla/chat/domain/vo/ChatChannelNameTest.java
@@ -1,0 +1,101 @@
+package one.colla.chat.domain.vo;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import one.colla.global.exception.VoException;
+
+class ChatChannelNameTest {
+
+	@Test
+	@DisplayName("두 객체의 값이 같으면 같은 객체이다.")
+	void testEqualsAndHashCode1() {
+		// given
+		String input = "channelName";
+
+		// when
+		ChatChannelName chatChannelName1 = ChatChannelName.from(input);
+		ChatChannelName chatChannelName2 = ChatChannelName.from(input);
+
+		// then
+		assertThat(chatChannelName1).isEqualTo(chatChannelName2);
+	}
+
+	@Test
+	@DisplayName("두 객체의 값이 다르면 다른 객체이다.")
+	void testEqualsAndHashCode2() {
+		// given
+		String input1 = "channelName1";
+		String input2 = "channelName2";
+
+		// when
+		ChatChannelName chatChannelName1 = ChatChannelName.from(input1);
+		ChatChannelName chatChannelName2 = ChatChannelName.from(input2);
+
+		// then
+		assertThat(chatChannelName1).isNotEqualTo(chatChannelName2);
+	}
+
+	@Test
+	@DisplayName("유효한 채널 이름을 생성할 수 있다.")
+	void testValidChatChannelName() {
+		// given
+		String input = "ValidChannel";
+
+		// when
+		ChatChannelName chatChannelName = ChatChannelName.from(input);
+
+		// then
+		assertThat(chatChannelName.getValue()).isEqualTo(input);
+	}
+
+	@Test
+	@DisplayName("채널 이름 글자 수는 1자 미만일 수 없다.")
+	void testChatChannelNameTooShort() {
+		// given
+		String input = "";
+
+		// when & then
+		assertThatThrownBy(() -> ChatChannelName.from(input))
+			.isInstanceOf(VoException.class)
+			.hasMessage("채팅 채널 이름은 1자 이상이어야 합니다.");
+	}
+
+	@Test
+	@DisplayName("채널 이름 글자 수는 15자 초과일 수 없다.")
+	void testChatChannelNameTooLong() {
+		// given
+		String input = "L".repeat(15 + 1);
+
+		// when & then
+		assertThatThrownBy(() -> ChatChannelName.from(input))
+			.isInstanceOf(VoException.class)
+			.hasMessageContaining("채팅 채널 이름은 1자 이상, 15자 이하여야 합니다.");
+	}
+
+	@Test
+	@DisplayName("채널 이름은 null이 될 수 없다.")
+	void testChatChannelNameNull() {
+		// given
+		String input = null;
+
+		// when & then
+		assertThatThrownBy(() -> ChatChannelName.from(input))
+			.isInstanceOf(VoException.class)
+			.hasMessageContaining("채팅 채널 이름은 null 일 수 없습니다.");
+	}
+
+	@Test
+	@DisplayName("채널 이름은 공백일 수 없다.")
+	void testChatChannelNameBlank() {
+		// given
+		String input = "   ";
+
+		// when & then
+		assertThatThrownBy(() -> ChatChannelName.from(input))
+			.isInstanceOf(VoException.class)
+			.hasMessageContaining("채팅 채널 이름은 공백일 수 없습니다.");
+	}
+}

--- a/src/test/java/one/colla/chat/presentation/ChatControllerTest.java
+++ b/src/test/java/one/colla/chat/presentation/ChatControllerTest.java
@@ -31,7 +31,7 @@ import one.colla.chat.application.dto.request.UpdateChatChannelNameRequest;
 import one.colla.chat.application.dto.response.ChatChannelInfoDto;
 import one.colla.chat.application.dto.response.ChatChannelMessageAttachmentDto;
 import one.colla.chat.application.dto.response.ChatChannelMessageAuthorDto;
-import one.colla.chat.application.dto.response.ChatChannelMessageInfoDto;
+import one.colla.chat.application.dto.response.ChatChannelMessageResponse;
 import one.colla.chat.application.dto.response.ChatChannelMessagesResponse;
 import one.colla.chat.application.dto.response.ChatChannelsResponse;
 import one.colla.chat.application.dto.response.CreateChatChannelResponse;
@@ -284,8 +284,8 @@ class ChatControllerTest extends ControllerTest {
 		final Long beforeChatMessageId = 50L;
 		final int limit = 50;
 
-		final List<ChatChannelMessageInfoDto> chatChannelMessageInfoDtos = List.of(
-			ChatChannelMessageInfoDto.builder()
+		final List<ChatChannelMessageResponse> chatChannelMessageResponses = List.of(
+			ChatChannelMessageResponse.builder()
 				.id(1L)
 				.type(ChatType.TEXT)
 				.chatChannelId(chatChannelId)
@@ -305,7 +305,7 @@ class ChatControllerTest extends ControllerTest {
 				.createdAt(LocalDateTime.of(2024, 5, 8, 4, 12, 34))
 				.build()
 		);
-		final ChatChannelMessagesResponse response = ChatChannelMessagesResponse.from(chatChannelMessageInfoDtos);
+		final ChatChannelMessagesResponse response = ChatChannelMessagesResponse.from(chatChannelMessageResponses);
 
 		@DisplayName("채팅 채널 메시지 조회 성공")
 		@WithMockCustomUser

--- a/src/test/java/one/colla/chat/presentation/ChatControllerTest.java
+++ b/src/test/java/one/colla/chat/presentation/ChatControllerTest.java
@@ -1,0 +1,111 @@
+package one.colla.chat.presentation;
+
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.Schema;
+
+import one.colla.chat.application.ChatChannelService;
+import one.colla.chat.application.dto.request.CreateChatChannelRequest;
+import one.colla.chat.application.dto.response.CreateChatChannelResponse;
+import one.colla.common.ControllerTest;
+import one.colla.common.presentation.ApiResponse;
+import one.colla.common.security.authentication.CustomUserDetails;
+import one.colla.common.security.authentication.WithMockCustomUser;
+import one.colla.global.exception.CommonException;
+import one.colla.global.exception.ExceptionCode;
+
+@WebMvcTest(ChatController.class)
+class ChatControllerTest extends ControllerTest {
+
+	@MockBean
+	private ChatChannelService chatChannelService;
+
+	@Nested
+	@DisplayName("채팅 채널 생성 문서화")
+	class CreateChatChannelDocs {
+		final Long teamspaceId = 1L;
+		final CreateChatChannelRequest request = new CreateChatChannelRequest("새로운 채팅 채널");
+		final CreateChatChannelResponse response = new CreateChatChannelResponse(1L);
+
+		@DisplayName("채팅 채널 생성 성공")
+		@WithMockCustomUser
+		@Test
+		void createChatChannel_Success() throws Exception {
+
+			given(chatChannelService.createChatChannel(any(CustomUserDetails.class), eq(teamspaceId), eq(request)))
+				.willReturn(response);
+
+			doTest(
+				ApiResponse.createSuccessResponse(response),
+				status().isCreated(),
+				apiDocHelper.createSuccessResponseFields(
+					fieldWithPath("chatChannelId").description("생성된 채팅 채널 Id")
+				),
+				"ApiResponse<CreateChatChannelResponse>"
+			);
+		}
+
+		@DisplayName("채팅 채널 생성 실패 - 접근 권한이 없거나 존재하지 않는 팀스페이스")
+		@WithMockCustomUser
+		@Test
+		void createChatChannel_Fail() throws Exception {
+			willThrow(new CommonException(ExceptionCode.FORBIDDEN_TEAMSPACE)).given(chatChannelService)
+				.createChatChannel(any(CustomUserDetails.class), eq(teamspaceId), eq(request));
+
+			doTest(
+				ApiResponse.createErrorResponse(ExceptionCode.FORBIDDEN_TEAMSPACE),
+				status().isForbidden(),
+				apiDocHelper.createErrorResponseFields(),
+				"ApiResponse"
+			);
+
+		}
+
+		private void doTest(
+			ApiResponse<?> response,
+			ResultMatcher statusMatcher,
+			FieldDescriptor[] responseFields,
+			String responseSchemaTitle
+		) throws Exception {
+			mockMvc.perform(
+					post("/api/v1/teamspaces/{teamspaceId}/chat-channels", teamspaceId)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(objectMapper.writeValueAsString(request))
+						.with(csrf()))
+				.andExpect(statusMatcher)
+				.andExpect(content().json(objectMapper.writeValueAsString(response)))
+				.andDo(restDocs.document(
+					resource(ResourceSnippetParameters.builder()
+						.tag("chatChannel-controller")
+						.description("채팅 채널을 생성합니다.")
+						.pathParameters(
+							parameterWithName("teamspaceId").description("팀스페이스 ID")
+						)
+						.responseFields(responseFields)
+						.requestSchema(Schema.schema("CreateChatChannelRequest"))
+						.responseSchema(Schema.schema(responseSchemaTitle))
+						.build()
+					)
+				)).andDo(print());
+
+		}
+	}
+
+}

--- a/src/test/java/one/colla/common/builder/BuilderSupporter.java
+++ b/src/test/java/one/colla/common/builder/BuilderSupporter.java
@@ -3,6 +3,9 @@ package one.colla.common.builder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import one.colla.chat.domain.ChatChannelMessageRepository;
+import one.colla.chat.domain.ChatChannelRepository;
+import one.colla.chat.domain.UserChatChannelRepository;
 import one.colla.teamspace.domain.TagRepository;
 import one.colla.teamspace.domain.TeamspaceRepository;
 import one.colla.teamspace.domain.UserTeamspaceRepository;
@@ -23,6 +26,15 @@ public class BuilderSupporter {
 	@Autowired
 	private TagRepository tagRepository;
 
+	@Autowired
+	private ChatChannelRepository chatChannelRepository;
+
+	@Autowired
+	private UserChatChannelRepository userChatChannelRepository;
+
+	@Autowired
+	private ChatChannelMessageRepository chatChannelMessageRepository;
+
 	public UserRepository userRepository() {
 		return userRepository;
 	}
@@ -38,4 +50,17 @@ public class BuilderSupporter {
 	public TagRepository tagRepository() {
 		return tagRepository;
 	}
+
+	public ChatChannelRepository chatChannelRepository() {
+		return chatChannelRepository;
+	}
+
+	public UserChatChannelRepository userChatChannelRepository() {
+		return userChatChannelRepository;
+	}
+
+	public ChatChannelMessageRepository chatChannelMessageRepository() {
+		return chatChannelMessageRepository;
+	}
+
 }

--- a/src/test/java/one/colla/common/builder/TestFixtureBuilder.java
+++ b/src/test/java/one/colla/common/builder/TestFixtureBuilder.java
@@ -5,6 +5,9 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import one.colla.chat.domain.ChatChannel;
+import one.colla.chat.domain.ChatChannelMessage;
+import one.colla.chat.domain.UserChatChannel;
 import one.colla.teamspace.domain.Tag;
 import one.colla.teamspace.domain.Teamspace;
 import one.colla.teamspace.domain.UserTeamspace;
@@ -38,5 +41,17 @@ public class TestFixtureBuilder {
 
 	public Tag buildTag(Tag tag) {
 		return bs.tagRepository().save(tag);
+	}
+
+	public ChatChannel buildChatChannel(ChatChannel chatChannel) {
+		return bs.chatChannelRepository().save(chatChannel);
+	}
+
+	public void buildUserChatChannel(List<UserChatChannel> userChatChannels) {
+		bs.userChatChannelRepository().saveAll(userChatChannels);
+	}
+
+	public ChatChannelMessage buildChatChannelMessage(ChatChannelMessage chatChannelMessage) {
+		return bs.chatChannelMessageRepository().save(chatChannelMessage);
 	}
 }

--- a/src/test/java/one/colla/common/fixtures/ChatChannelFixtures.java
+++ b/src/test/java/one/colla/common/fixtures/ChatChannelFixtures.java
@@ -1,0 +1,17 @@
+package one.colla.common.fixtures;
+
+import one.colla.chat.domain.ChatChannel;
+import one.colla.teamspace.domain.Teamspace;
+
+public class ChatChannelFixtures {
+	public static final String FRONTEND_CHAT_CHANNEL_NAME = "프론트엔드 채팅 채널";
+	public static final String BACKEND_CHAT_CHANNEL_NAME = "백엔드 채팅 채널";
+
+	public static ChatChannel FRONTEND_CHAT_CHANNEL(Teamspace teamspace) {
+		return ChatChannel.of(teamspace, FRONTEND_CHAT_CHANNEL_NAME);
+	}
+
+	public static ChatChannel BACKEND_CHAT_CHANNEL(Teamspace teamspace) {
+		return ChatChannel.of(teamspace, BACKEND_CHAT_CHANNEL_NAME);
+	}
+}

--- a/src/test/java/one/colla/common/fixtures/ChatChannelMessageFixtures.java
+++ b/src/test/java/one/colla/common/fixtures/ChatChannelMessageFixtures.java
@@ -2,21 +2,25 @@ package one.colla.common.fixtures;
 
 import java.util.UUID;
 
+import one.colla.chat.application.dto.request.ChatCreateRequest;
 import one.colla.chat.domain.ChatChannel;
 import one.colla.chat.domain.ChatChannelMessage;
 import one.colla.chat.domain.ChatType;
+import one.colla.teamspace.domain.Teamspace;
 import one.colla.user.domain.User;
 
 public class ChatChannelMessageFixtures {
 	public static final String CHAT_MESSAGE1_CONTENT = "메시지_1";
 
-	public static ChatChannelMessage RANDOM_CHAT_MESSAGE(User user, ChatChannel chatChannel, ChatType chatType) {
+	public static ChatChannelMessage RANDOM_CHAT_MESSAGE(User user, Teamspace teamspace, ChatChannel chatChannel) {
 		String randomMessageContent = "메시지_" + UUID.randomUUID().toString().substring(0, 8);
-		return ChatChannelMessage.of(user, chatChannel, chatType, randomMessageContent);
+		ChatCreateRequest chatCreateRequest = new ChatCreateRequest(ChatType.TEXT, randomMessageContent, null, null);
+		return ChatChannelMessage.of(user, teamspace, chatChannel, chatCreateRequest);
 	}
 
-	public static ChatChannelMessage CHAT_MESSAGE1(User user, ChatChannel chatChannel, ChatType chatType) {
-		return ChatChannelMessage.of(user, chatChannel, chatType, CHAT_MESSAGE1_CONTENT);
+	public static ChatChannelMessage CHAT_MESSAGE1(User user, Teamspace teamspace, ChatChannel chatChannel) {
+		ChatCreateRequest chatCreateRequest = new ChatCreateRequest(ChatType.TEXT, CHAT_MESSAGE1_CONTENT, null, null);
+		return ChatChannelMessage.of(user, teamspace, chatChannel, chatCreateRequest);
 	}
 
 }

--- a/src/test/java/one/colla/common/fixtures/ChatChannelMessageFixtures.java
+++ b/src/test/java/one/colla/common/fixtures/ChatChannelMessageFixtures.java
@@ -1,0 +1,15 @@
+package one.colla.common.fixtures;
+
+import one.colla.chat.domain.ChatChannel;
+import one.colla.chat.domain.ChatChannelMessage;
+import one.colla.chat.domain.ChatType;
+import one.colla.user.domain.User;
+
+public class ChatChannelMessageFixtures {
+	public static final String CHAT_MESSAGE1_CONTENT = "메시지1 내용";
+
+	public static ChatChannelMessage CHAT_MESSAGE1(User user, ChatChannel chatChannel, ChatType chatType) {
+		return ChatChannelMessage.of(user, chatChannel, chatType, CHAT_MESSAGE1_CONTENT);
+	}
+
+}

--- a/src/test/java/one/colla/common/fixtures/ChatChannelMessageFixtures.java
+++ b/src/test/java/one/colla/common/fixtures/ChatChannelMessageFixtures.java
@@ -1,12 +1,19 @@
 package one.colla.common.fixtures;
 
+import java.util.UUID;
+
 import one.colla.chat.domain.ChatChannel;
 import one.colla.chat.domain.ChatChannelMessage;
 import one.colla.chat.domain.ChatType;
 import one.colla.user.domain.User;
 
 public class ChatChannelMessageFixtures {
-	public static final String CHAT_MESSAGE1_CONTENT = "메시지1 내용";
+	public static final String CHAT_MESSAGE1_CONTENT = "메시지_1";
+
+	public static ChatChannelMessage RANDOM_CHAT_MESSAGE(User user, ChatChannel chatChannel, ChatType chatType) {
+		String randomMessageContent = "메시지_" + UUID.randomUUID().toString().substring(0, 8);
+		return ChatChannelMessage.of(user, chatChannel, chatType, randomMessageContent);
+	}
 
 	public static ChatChannelMessage CHAT_MESSAGE1(User user, ChatChannel chatChannel, ChatType chatType) {
 		return ChatChannelMessage.of(user, chatChannel, chatType, CHAT_MESSAGE1_CONTENT);


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-backend/issues/56

## ✨ PR 세부 내용
- STOMP를 사용한 소켓 연결 환경 설정 
- 소켓 연결 HandShake 과정 중 JWT Token 검사를 위한 `HandshakeInterceptor` 구현
- 채팅 채널 생성, 삭제, 수정(채팅 채널명) API 개발
- 채팅 채널의 메시지 목록 조회 API 개발
- 채팅 메시지 소켓 `구독(수신)`/`발행(전송)` API 개발

**일정이 급한 관계로 성능 개선은 추후에 진행하겠습니다!**


## ✅ 리뷰 요구사항

- chat 관련 도메인 들의 cascade, orphanRemoval 설정이 잘 되었는지 자세히 봐주세요!