### PR TITLE
채팅 읽음 처리 및 채팅 채널 상태 업데이트 API 개발

### DIFF
--- a/src/main/java/one/colla/chat/application/ChatWebSocketService.java
+++ b/src/main/java/one/colla/chat/application/ChatWebSocketService.java
@@ -1,5 +1,6 @@
 package one.colla.chat.application;
 
+import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -8,12 +9,16 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import one.colla.chat.application.dto.request.ChatCreateRequest;
+import one.colla.chat.application.dto.response.ChatChannelInfoDto;
 import one.colla.chat.application.dto.response.ChatChannelMessageAttachmentDto;
 import one.colla.chat.application.dto.response.ChatChannelMessageAuthorDto;
 import one.colla.chat.application.dto.response.ChatChannelMessageResponse;
+import one.colla.chat.application.dto.response.ChatChannelStatusResponse;
 import one.colla.chat.domain.ChatChannel;
 import one.colla.chat.domain.ChatChannelMessage;
 import one.colla.chat.domain.ChatChannelMessageRepository;
+import one.colla.chat.domain.UserChatChannel;
+import one.colla.chat.domain.UserChatChannelRepository;
 import one.colla.common.security.authentication.CustomUserDetails;
 import one.colla.global.exception.CommonException;
 import one.colla.global.exception.ExceptionCode;
@@ -30,45 +35,89 @@ public class ChatWebSocketService {
 	private final TeamspaceService teamspaceService;
 	private final UserRepository userRepository;
 	private final ChatChannelMessageRepository chatChannelMessageRepository;
+	private final ChatChannelService chatChannelService;
+	private final UserChatChannelRepository userChatChannelRepository;
 
-	// TODO: 소켓 통신이지만 RDB에 너무 많은 접근이 있음. 추후 성능 개선 필요
 	@Transactional
 	public ChatChannelMessageResponse processMessage(
 		ChatCreateRequest request, Long userId, Long teamspaceId, Long chatChannelId) {
 
-		log.info(request.toString());
+		User user = findUserById(userId);
+		CustomUserDetails customUserDetails = CustomUserDetails.from(user);
 
-		User user = userRepository.findById(userId)
-			.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_USER));
+		UserTeamspace userTeamspace = teamspaceService.getUserTeamspace(customUserDetails, teamspaceId);
+		ChatChannel chatChannel = findChatChannel(userTeamspace, chatChannelId);
+
+		ChatChannelMessage chatChannelMessage = createAndSaveChatMessage(request, user, userTeamspace, chatChannel);
+
+		log.info("채팅 메시지 생성 & 저장 - 사용자 Id: {}, 팀스페이스 Id: {}, 채널 Id: {}", userId, teamspaceId, chatChannelId);
+
+		chatChannel.updateLastChatMessage(chatChannelMessage.getId());
+
+		ChatChannelMessageResponse response = createChatMessageResponse(user, chatChannelMessage);
+
+		log.info("채팅 메시지 응답 생성 - 사용자 Id: {}, 팀스페이스 Id: {}, 채널 Id: {}", userId, teamspaceId, chatChannelId);
+
+		return response;
+	}
+
+	@Transactional(readOnly = true)
+	public ChatChannelStatusResponse getChatChannelsStatus(Long userId, Long teamspaceId) {
+		User user = findUserById(userId);
 		CustomUserDetails customUserDetails = CustomUserDetails.from(user);
 
 		UserTeamspace userTeamspace = teamspaceService.getUserTeamspace(customUserDetails, teamspaceId);
 
-		ChatChannel chatChannel = findChatChannel(userTeamspace, chatChannelId);
+		List<ChatChannelInfoDto> chatChannelInfoDtos = userTeamspace.getTeamspace().getChatChannels().stream()
+			.map(ch -> chatChannelService.createChatChannelInfoDto(ch, userId))
+			.sorted(Comparator.comparing(ChatChannelInfoDto::lastChatCreatedAt,
+				Comparator.nullsLast(Comparator.reverseOrder())))
+			.toList();
 
+		return ChatChannelStatusResponse.from(chatChannelInfoDtos);
+	}
+
+	@Transactional
+	public void markMessageAsRead(Long userId, Long teamspaceId, Long chatChannelId, Long messageId) {
+		User user = findUserById(userId);
+		CustomUserDetails customUserDetails = CustomUserDetails.from(user);
+
+		validateParticipationInTeamspace(teamspaceId, customUserDetails);
+
+		UserChatChannel userChatChannel = userChatChannelRepository.findByUserIdAndChatChannelId(userId, chatChannelId)
+			.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_CHAT_CHANNEL));
+
+		if (userChatChannel.getLastReadMessageId() == null || userChatChannel.getLastReadMessageId() < messageId) {
+			userChatChannel.updateLastReadMessageId(messageId);
+			userChatChannelRepository.save(userChatChannel);
+		}
+	}
+
+	private void validateParticipationInTeamspace(Long teamspaceId, CustomUserDetails customUserDetails) {
+		teamspaceService.getUserTeamspace(customUserDetails, teamspaceId);
+	}
+
+	private ChatChannelMessage createAndSaveChatMessage(ChatCreateRequest request, User user,
+		UserTeamspace userTeamspace, ChatChannel chatChannel) {
 		ChatChannelMessage chatChannelMessage = ChatChannelMessage.of(
 			user, userTeamspace.getTeamspace(), chatChannel, request);
-
 		chatChannelMessageRepository.save(chatChannelMessage);
+		return chatChannelMessage;
+	}
 
-		log.info("채팅 메시지 생성 & 저장  - 사용자 Id: {}, 팀스페이스 Id: {}, 채널 Id: {}", userId, teamspaceId, chatChannelId);
-
-		chatChannel.updateLastChatMessage(chatChannelMessage.getId());
-
+	private ChatChannelMessageResponse createChatMessageResponse(User user, ChatChannelMessage chatChannelMessage) {
 		ChatChannelMessageAuthorDto chatChannelMessageAuthorDto = ChatChannelMessageAuthorDto.from(user);
 		List<ChatChannelMessageAttachmentDto> chatChannelMessageAttachmentDtos =
 			chatChannelMessage.getChatChannelMessageAttachments().stream()
-				.map(ChatChannelMessageAttachmentDto::from).toList();
-
-		log.info("채팅 메시지 응답 생성 - 사용자 Id: {}, 팀스페이스 Id: {}, 채널 Id: {}", userId, teamspaceId, chatChannelId);
-
-		return ChatChannelMessageResponse.of(
-			chatChannelMessage, chatChannelMessageAuthorDto, chatChannelMessageAttachmentDtos);
+				.map(ChatChannelMessageAttachmentDto::from)
+				.toList();
+		return ChatChannelMessageResponse.of(chatChannelMessage, chatChannelMessageAuthorDto,
+			chatChannelMessageAttachmentDtos);
 	}
 
-	@Transactional(readOnly = true)
-	public void getChatChannelStatuses(Long userId, Long teamspaceId, Long chatChannelId) {
-
+	private User findUserById(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new CommonException(ExceptionCode.NOT_FOUND_USER));
 	}
 
 	private ChatChannel findChatChannel(UserTeamspace userTeamspace, Long chatChannelId) {

--- a/src/main/java/one/colla/chat/application/ChatWebSocketService.java
+++ b/src/main/java/one/colla/chat/application/ChatWebSocketService.java
@@ -53,6 +53,8 @@ public class ChatWebSocketService {
 
 		log.info("채팅 메시지 생성 & 저장  - 사용자 Id: {}, 팀스페이스 Id: {}, 채널 Id: {}", userId, teamspaceId, chatChannelId);
 
+		chatChannel.updateLastChatMessage(chatChannelMessage.getId());
+
 		ChatChannelMessageAuthorDto chatChannelMessageAuthorDto = ChatChannelMessageAuthorDto.from(user);
 		List<ChatChannelMessageAttachmentDto> chatChannelMessageAttachmentDtos =
 			chatChannelMessage.getChatChannelMessageAttachments().stream()
@@ -62,6 +64,11 @@ public class ChatWebSocketService {
 
 		return ChatChannelMessageResponse.of(
 			chatChannelMessage, chatChannelMessageAuthorDto, chatChannelMessageAttachmentDtos);
+	}
+
+	@Transactional(readOnly = true)
+	public void getChatChannelStatuses(Long userId, Long teamspaceId, Long chatChannelId) {
+
 	}
 
 	private ChatChannel findChatChannel(UserTeamspace userTeamspace, Long chatChannelId) {

--- a/src/main/java/one/colla/chat/application/dto/response/ChatChannelInfoDto.java
+++ b/src/main/java/one/colla/chat/application/dto/response/ChatChannelInfoDto.java
@@ -16,15 +16,17 @@ public record ChatChannelInfoDto(
 	String lastChatMessage,
 	@JsonSerialize(using = LocalDateTimeSerializer.class)
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
-	LocalDateTime lastChatCreatedAt
+	LocalDateTime lastChatCreatedAt,
+	int unreadMessageCount
 ) {
 	public static ChatChannelInfoDto of(ChatChannel chatChannel, String lastChatMessage,
-		LocalDateTime lastChatCreatedAt) {
+		LocalDateTime lastChatCreatedAt, int unreadMessageCount) {
 		return ChatChannelInfoDto.builder()
 			.id(chatChannel.getId())
 			.name(chatChannel.getChatChannelName().getValue())
 			.lastChatMessage(lastChatMessage)
 			.lastChatCreatedAt(lastChatCreatedAt)
+			.unreadMessageCount(unreadMessageCount)
 			.build();
 	}
 }

--- a/src/main/java/one/colla/chat/application/dto/response/ChatChannelStatusResponse.java
+++ b/src/main/java/one/colla/chat/application/dto/response/ChatChannelStatusResponse.java
@@ -1,0 +1,11 @@
+package one.colla.chat.application.dto.response;
+
+import java.util.List;
+
+public record ChatChannelStatusResponse(
+	List<ChatChannelInfoDto> chatChannelsResponse
+) {
+	public static ChatChannelStatusResponse from(List<ChatChannelInfoDto> chatChannelsResponse) {
+		return new ChatChannelStatusResponse(chatChannelsResponse);
+	}
+}

--- a/src/main/java/one/colla/chat/domain/ChatChannel.java
+++ b/src/main/java/one/colla/chat/domain/ChatChannel.java
@@ -55,6 +55,12 @@ public class ChatChannel extends BaseEntity {
 		return new ChatChannel(teamspace, name);
 	}
 
+	public UserChatChannel participateTeamspaceUser(UserTeamspace userTeamspace) {
+		UserChatChannel participateUser = UserChatChannel.of(userTeamspace.getUser(), this);
+		this.userChatChannels.add(participateUser);
+		return participateUser;
+	}
+
 	public List<UserChatChannel> participateAllTeamspaceUser(List<UserTeamspace> userTeamspaces) {
 		List<UserChatChannel> userChatChannelList = userTeamspaces.stream()
 			.map(ut -> UserChatChannel.of(ut.getUser(), this))

--- a/src/main/java/one/colla/chat/domain/ChatChannelMessageRepository.java
+++ b/src/main/java/one/colla/chat/domain/ChatChannelMessageRepository.java
@@ -34,4 +34,8 @@ public interface ChatChannelMessageRepository extends JpaRepository<ChatChannelM
 	Optional<ChatChannelMessage> findByIdAndChatChannel(Long beforeChatMessageId, ChatChannel chatChannel);
 
 	void deleteAllByChatChannel(ChatChannel chatChannel);
+
+	int countByChatChannel(ChatChannel chatChannel);
+
+	int countByChatChannelAndIdGreaterThan(ChatChannel chatChannel, Long id);
 }

--- a/src/main/java/one/colla/chat/domain/UserChatChannel.java
+++ b/src/main/java/one/colla/chat/domain/UserChatChannel.java
@@ -53,4 +53,8 @@ public class UserChatChannel extends BaseEntity {
 		@Column(name = "chat_channel_id")
 		private Long chatChannelId;
 	}
+
+	public void updateLastReadMessageId(Long lastReadMessageId) {
+		this.lastReadMessageId = lastReadMessageId;
+	}
 }

--- a/src/main/java/one/colla/chat/domain/UserChatChannelRepository.java
+++ b/src/main/java/one/colla/chat/domain/UserChatChannelRepository.java
@@ -1,6 +1,9 @@
 package one.colla.chat.domain;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserChatChannelRepository extends JpaRepository<UserChatChannel, Long> {
+	Optional<UserChatChannel> findByUserIdAndChatChannelId(Long userId, Long id);
 }

--- a/src/main/java/one/colla/chat/presentation/ChatWebSocketController.java
+++ b/src/main/java/one/colla/chat/presentation/ChatWebSocketController.java
@@ -38,6 +38,9 @@ public class ChatWebSocketController {
 		template.convertAndSend("/topic/teamspaces/" + teamspaceId + "/chat-channels/" + chatChannelId + "/messages",
 			response);
 		log.info("채팅 메시지 전송 - 사용자 Id: {}, 팀스페이스 Id: {}, 채널 Id: {}", userId, teamspaceId, chatChannelId);
+
+		template.convertAndSend("/topic/teamspaces/" + teamspaceId + "/chat-channels" + "/status-updates", response);
+		log.info("채팅 채널 상태 업데이트 - 사용자 Id: {}, 팀스페이스 Id: {}", userId, teamspaceId);
 	}
 
 	private Long getUserIdFromHeaderAccessor(StompHeaderAccessor headerAccessor) {

--- a/src/main/java/one/colla/chat/presentation/ChatWebSocketController.java
+++ b/src/main/java/one/colla/chat/presentation/ChatWebSocketController.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import one.colla.chat.application.ChatWebSocketService;
 import one.colla.chat.application.dto.request.ChatCreateRequest;
 import one.colla.chat.application.dto.response.ChatChannelMessageResponse;
+import one.colla.chat.application.dto.response.ChatChannelStatusResponse;
 
 @Slf4j
 @Controller
@@ -33,14 +34,41 @@ public class ChatWebSocketController {
 
 		Long userId = getUserIdFromHeaderAccessor(headerAccessor);
 
-		ChatChannelMessageResponse response = chatWebSocketService.processMessage(
+		ChatChannelMessageResponse chatChannelMessageResponse = chatWebSocketService.processMessage(
 			request, userId, teamspaceId, chatChannelId);
+
 		template.convertAndSend("/topic/teamspaces/" + teamspaceId + "/chat-channels/" + chatChannelId + "/messages",
-			response);
+			chatChannelMessageResponse);
 		log.info("채팅 메시지 전송 - 사용자 Id: {}, 팀스페이스 Id: {}, 채널 Id: {}", userId, teamspaceId, chatChannelId);
 
-		template.convertAndSend("/topic/teamspaces/" + teamspaceId + "/chat-channels" + "/status-updates", response);
-		log.info("채팅 채널 상태 업데이트 - 사용자 Id: {}, 팀스페이스 Id: {}", userId, teamspaceId);
+	}
+
+	@MessageMapping("/teamspaces/{teamspaceId}/chat-channels/status")
+	public void getChatChannelsStatus(
+		@DestinationVariable Long teamspaceId,
+		StompHeaderAccessor headerAccessor) {
+
+		Long userId = getUserIdFromHeaderAccessor(headerAccessor);
+
+		ChatChannelStatusResponse response = chatWebSocketService.getChatChannelsStatus(userId, teamspaceId);
+		template.convertAndSend("/topic/teamspaces/" + teamspaceId + "/chat-channels/status", response);
+
+		log.info("채팅 채널 상태 조회 - 사용자 Id: {}, 팀스페이스 Id: {}", userId, teamspaceId);
+	}
+
+	@MessageMapping("/teamspaces/{teamspaceId}/chat-channels/{chatChannelId}/messages/{messageId}/read")
+	public void markMessageAsRead(
+		@DestinationVariable Long teamspaceId,
+		@DestinationVariable Long chatChannelId,
+		@DestinationVariable Long messageId,
+		StompHeaderAccessor headerAccessor) {
+
+		Long userId = getUserIdFromHeaderAccessor(headerAccessor);
+
+		chatWebSocketService.markMessageAsRead(userId, teamspaceId, chatChannelId, messageId);
+
+		log.info("메시지 읽음 상태 업데이트 - 사용자 Id: {}, 팀스페이스 Id: {}, 채널 Id: {}, 메시지 Id: {}", userId, teamspaceId, chatChannelId,
+			messageId);
 	}
 
 	private Long getUserIdFromHeaderAccessor(StompHeaderAccessor headerAccessor) {

--- a/src/main/java/one/colla/global/exception/ExceptionCode.java
+++ b/src/main/java/one/colla/global/exception/ExceptionCode.java
@@ -40,6 +40,7 @@ public enum ExceptionCode {
 	/* 405xx CHAT */
 	NOT_FOUND_CHAT_CHANNEL(HttpStatus.NOT_FOUND, 40501, "해당 채팅 채널을 찾을 수 없습니다."),
 	NOT_FOUND_CHAT_CHANNEL_MESSAGE(HttpStatus.NOT_FOUND, 40502, "선택하신 채팅 채널에서 해당 메시지를 찾을 수 없습니다."),
+	NOT_FOUND_USER_CHAT_CHANNEL(HttpStatus.NOT_FOUND, 40503, "선택하신 채팅 채널에서 해당 유저를 찾을 수 없습니다."),
 
 	/* FEED-COMMON */
 	NOT_FOUND_FEED(HttpStatus.NOT_FOUND, 47101, "접근 권한이 없거나 존재하지 않는 피드입니다."),

--- a/src/main/java/one/colla/teamspace/application/TeamspaceService.java
+++ b/src/main/java/one/colla/teamspace/application/TeamspaceService.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import one.colla.chat.domain.UserChatChannel;
+import one.colla.chat.domain.UserChatChannelRepository;
 import one.colla.common.security.authentication.CustomUserDetails;
 import one.colla.common.util.RandomCodeGenerator;
 import one.colla.global.exception.CommonException;
@@ -59,6 +61,7 @@ public class TeamspaceService {
 	private final TagRepository tagRepository;
 	private final ApplicationEventPublisher publisher;
 	private final RandomCodeGenerator randomCodeGenerator;
+	private final UserChatChannelRepository userChatChannelRepository;
 
 	@Transactional
 	public CreateTeamspaceResponse create(final CustomUserDetails userDetails, final CreateTeamspaceRequest request) {
@@ -141,7 +144,11 @@ public class TeamspaceService {
 		}
 
 		final UserTeamspace participatedUserTeamspace = user.participate(teamspace, TeamspaceRole.MEMBER);
+		final List<UserChatChannel> participatedUserChatChannels = teamspace.getChatChannels().stream()
+			.map(ch -> ch.participateTeamspaceUser(participatedUserTeamspace))
+			.toList();
 		userTeamspaceRepository.save(participatedUserTeamspace);
+		userChatChannelRepository.saveAll(participatedUserChatChannels);
 		log.info("팀스페이스 참가 - 팀스페이스 Id: {}, 사용자 Id: {}", teamspaceId, user.getId());
 	}
 

--- a/src/test/java/one/colla/chat/application/ChatWebSocketServiceTest.java
+++ b/src/test/java/one/colla/chat/application/ChatWebSocketServiceTest.java
@@ -99,6 +99,7 @@ class ChatWebSocketServiceTest extends ServiceTest {
 				softly.assertThat(response.content()).isEqualTo(request.content());
 				softly.assertThat(response.chatChannelId()).isEqualTo(FRONTEND_CHAT_CHANNEL.getId());
 				softly.assertThat(response.author().id()).isEqualTo(USER1.getId());
+				softly.assertThat(FRONTEND_CHAT_CHANNEL.getLastChatId()).isEqualTo(response.id());
 			});
 
 			Optional<ChatChannelMessage> savedMessage = chatChannelMessageRepository.findById(response.id());
@@ -133,6 +134,7 @@ class ChatWebSocketServiceTest extends ServiceTest {
 				softly.assertThat(response.attachments()).hasSize(2);
 				softly.assertThat(response.attachments().get(0).filename()).isEqualTo(FILE1_NAME);
 				softly.assertThat(response.attachments().get(1).filename()).isEqualTo(FILE2_NAME);
+				softly.assertThat(FRONTEND_CHAT_CHANNEL.getLastChatId()).isEqualTo(response.id());
 			});
 
 			Optional<ChatChannelMessage> savedMessage = chatChannelMessageRepository.findById(response.id());
@@ -167,6 +169,7 @@ class ChatWebSocketServiceTest extends ServiceTest {
 				softly.assertThat(response.attachments()).hasSize(2);
 				softly.assertThat(response.attachments().get(0).filename()).isEqualTo(ATTACHMENT1_NAME);
 				softly.assertThat(response.attachments().get(1).filename()).isEqualTo(ATTACHMENT2_NAME);
+				softly.assertThat(FRONTEND_CHAT_CHANNEL.getLastChatId()).isEqualTo(response.id());
 			});
 
 			Optional<ChatChannelMessage> savedMessage = chatChannelMessageRepository.findById(response.id());

--- a/src/test/java/one/colla/chat/presentation/ChatControllerTest.java
+++ b/src/test/java/one/colla/chat/presentation/ChatControllerTest.java
@@ -126,7 +126,7 @@ class ChatControllerTest extends ControllerTest {
 		final Long teamspaceId = 1L;
 		final List<ChatChannelInfoDto> chatChannelInfoDtos = List.of(
 			new ChatChannelInfoDto(1L, "프론트엔드", "안녕하세요",
-				LocalDateTime.of(2024, 5, 8, 4, 12, 34))
+				LocalDateTime.of(2024, 5, 8, 4, 12, 34), 0)
 		);
 		final ChatChannelsResponse response = ChatChannelsResponse.from(chatChannelInfoDtos);
 
@@ -146,7 +146,8 @@ class ChatControllerTest extends ControllerTest {
 					fieldWithPath("chatChannels[].id").description("채팅 채널 ID"),
 					fieldWithPath("chatChannels[].name").description("채팅 채널 이름"),
 					fieldWithPath("chatChannels[].lastChatMessage").description("채팅 채널 마지막 메시지 내용"),
-					fieldWithPath("chatChannels[].lastChatCreatedAt").description("채팅 채널 마지막 메시지 생성 시간")
+					fieldWithPath("chatChannels[].lastChatCreatedAt").description("채팅 채널 마지막 메시지 생성 시간"),
+					fieldWithPath("chatChannels[].unreadMessageCount").description("채팅 채널 안읽은 메시지 개수")
 				),
 				"ApiResponse<ChatChannelsResponse>"
 			);

--- a/src/test/java/one/colla/common/builder/TestFixtureBuilder.java
+++ b/src/test/java/one/colla/common/builder/TestFixtureBuilder.java
@@ -48,8 +48,8 @@ public class TestFixtureBuilder {
 		return bs.chatChannelRepository().save(chatChannel);
 	}
 
-	public void buildUserChatChannel(List<UserChatChannel> userChatChannels) {
-		bs.userChatChannelRepository().saveAll(userChatChannels);
+	public List<UserChatChannel> buildUserChatChannel(List<UserChatChannel> userChatChannels) {
+		return bs.userChatChannelRepository().saveAll(userChatChannels);
 	}
 
 	public ChatChannelMessage buildChatChannelMessage(ChatChannelMessage chatChannelMessage) {

--- a/src/test/java/one/colla/common/fixtures/ChatChannelFixtures.java
+++ b/src/test/java/one/colla/common/fixtures/ChatChannelFixtures.java
@@ -6,6 +6,7 @@ import one.colla.teamspace.domain.Teamspace;
 public class ChatChannelFixtures {
 	public static final String FRONTEND_CHAT_CHANNEL_NAME = "프론트엔드 채팅 채널";
 	public static final String BACKEND_CHAT_CHANNEL_NAME = "백엔드 채팅 채널";
+	public static final String NO_EXIST_CHAT_CHANNEL_NAME = "존재하지 않는 채널";
 
 	public static ChatChannel FRONTEND_CHAT_CHANNEL(Teamspace teamspace) {
 		return ChatChannel.of(teamspace, FRONTEND_CHAT_CHANNEL_NAME);
@@ -13,5 +14,9 @@ public class ChatChannelFixtures {
 
 	public static ChatChannel BACKEND_CHAT_CHANNEL(Teamspace teamspace) {
 		return ChatChannel.of(teamspace, BACKEND_CHAT_CHANNEL_NAME);
+	}
+
+	public static ChatChannel NO_EXIST_CHAT_CHANNEL(Teamspace teamspace) {
+		return ChatChannel.of(teamspace, NO_EXIST_CHAT_CHANNEL_NAME);
 	}
 }


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-backend/issues/68

## ✨ PR 세부 내용

- 유저별 채팅 메시지 읽음 처리 소켓 API
- 채팅 채널 상태 업데이트 소켓 API
- 채널 정보 dto에 읽지 않은 채팅 메시지 개수 추가
- 관련 테스트 작성