### PR TITLE
Service Test 코드 리팩터링

### DIFF
--- a/src/test/java/one/colla/common/ServiceTestV2.java
+++ b/src/test/java/one/colla/common/ServiceTestV2.java
@@ -1,0 +1,33 @@
+package one.colla.common;
+
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.event.RecordApplicationEvents;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@ActiveProfiles("test")
+@SpringJUnitConfig
+@RecordApplicationEvents
+@Import(ServiceTestConfig.class)
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface ServiceTestV2 {
+}
+
+
+@TestConfiguration
+class ServiceTestConfig {
+
+//	@Bean
+//	public TestFixtureBuilder testFixtureBuilder() {
+//		return new TestFixtureBuilder();
+//	}
+
+}

--- a/src/test/java/one/colla/common/UnitTest.java
+++ b/src/test/java/one/colla/common/UnitTest.java
@@ -15,15 +15,15 @@ import java.lang.annotation.Target;
 @ActiveProfiles("test")
 @SpringJUnitConfig
 @RecordApplicationEvents
-@Import(ServiceTestConfig.class)
+@Import(UnitTestCommonConfig.class)
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-public @interface ServiceTestV2 {
+public @interface UnitTest {
 }
 
 
 @TestConfiguration
-class ServiceTestConfig {
+class UnitTestCommonConfig {
 
 //	@Bean
 //	public TestFixtureBuilder testFixtureBuilder() {


### PR DESCRIPTION
## 📌 관련 이슈

- closed: https://github.com/98OO/colla-backend/issues/86

## ✨ PR 세부 내용

#### **어노테이션 기반의 ServiceTest 코드 작성**
- MockBean을 사용한다고 가정하고 @Transactional을 제거했습니다.
- @SpringBootTest에서 @SpringJunitConfig로 변경을 통해 무거운 스프링 부트 기반 테스트(모든 빈을 다 등록함.)에서 가벼운 테스트 환경을 구축하였습니다.
- UnitTest 내의 UnitTestCommonConfig에 유닛 테스트에서 사용할 공통 빈을 등록할 수 있도록 Config 클래스를 생성하였습니다.

#### **AuthServiceTest에 @ServiceTestV2 적용 및 이에 따른 AuthServiceTest 수정**
- AuthServiceTest가 @UnitTest 를 사용하도록 변경하였습니다.
- 기존의 Mock을 주입하던 코드에서 MockBean을 주입하도록 변경하였습니다.
- AuthServiceTestConfig에서 AuthServiceTest에서만 사용하는 빈을 Config를 통해 등록하는 코드를 추가하였습니다.



## ✅ 리뷰 요구사항
- 기존의 Mock환경에서 동작하던 publisher 검증 코드는(AuthService 317 line), 스프링 내부의 빈 등록 문제로 인해 MockBean이 정상 주입되지 못하는 문제가 존재함을 확인했습니다. 따라서 EmailSendEventListener 클래스를 생성해주어 실제 이벤트를 받는 객체를 생성해 테스트를 수행하도록 변경하였습니다. 이에 대해 개선사항이 있다면 말씀해주시면 감사하겠습니다.

- 관련 링크 : https://github.com/spring-projects/spring-boot/issues/6060

