### PR TITLE
RefreshToken 만료 에러 코드 추가

### DIFF
--- a/src/main/java/one/colla/common/security/filter/JwtExceptionFilter.java
+++ b/src/main/java/one/colla/common/security/filter/JwtExceptionFilter.java
@@ -27,7 +27,7 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
 	private static final String CHARACTER_ENCODING = "UTF-8";
 
 	private static final Map<Class<? extends JwtException>, ExceptionCode> JWT_EXCEPTION_CODE_MAP = Map.of(
-		ExpiredJwtException.class, ExceptionCode.EXPIRED_TOKEN,
+		ExpiredJwtException.class, ExceptionCode.EXPIRED_ACCESS_TOKEN,
 		MalformedJwtException.class, ExceptionCode.MALFORMED_TOKEN,
 		SignatureException.class, ExceptionCode.TAMPERED_TOKEN,
 		UnsupportedJwtException.class, ExceptionCode.UNSUPPORTED_JWT_TOKEN

--- a/src/main/java/one/colla/common/security/jwt/refresh/RefreshTokenProvider.java
+++ b/src/main/java/one/colla/common/security/jwt/refresh/RefreshTokenProvider.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import javax.crypto.SecretKey;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -21,8 +22,8 @@ import one.colla.common.security.jwt.JwtClaims;
 import one.colla.common.security.jwt.JwtProvider;
 import one.colla.common.security.jwt.access.AccessTokenClaim;
 
+@Component
 public class RefreshTokenProvider implements JwtProvider {
-
 	private final SecretKey secretKey;
 	private final Duration tokenExpiration;
 

--- a/src/main/java/one/colla/global/exception/ExceptionCode.java
+++ b/src/main/java/one/colla/global/exception/ExceptionCode.java
@@ -19,11 +19,12 @@ public enum ExceptionCode {
 	SOCIAL_EMAIL_ALREADY_REGISTERED(HttpStatus.UNAUTHORIZED, 40107, "소셜 로그인으로 가입한 이메일 입니다."),
 	FORBIDDEN_ACCESS_TOKEN(HttpStatus.FORBIDDEN, 40181, "토큰에 접근 권한이 없습니다."),
 	EMPTY_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, 40182, "토큰이 포함되어 있지 않습니다."),
-	EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, 40183, "사용기간이 만료된 토큰입니다."),
+	EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, 40183, "재 로그인이 필요합니다."),
 	MALFORMED_TOKEN(HttpStatus.UNAUTHORIZED, 40184, "비정상적인 토큰입니다."),
 	TAMPERED_TOKEN(HttpStatus.UNAUTHORIZED, 40185, "서명이 조작된 토큰입니다."),
 	UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, 40186, "지원하지 않는 토큰입니다."),
 	TAKEN_AWAY_TOKEN(HttpStatus.FORBIDDEN, 40187, "인증 불가, 관리자에게 문의하세요."),
+	EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, 40188, "재 로그인이 필요합니다."),
 
 	/* 402xx USER */
 	NOT_FOUND_USER(HttpStatus.NOT_FOUND, 40201, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/one/colla/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/one/colla/global/handler/GlobalExceptionHandler.java
@@ -42,7 +42,7 @@ import one.colla.global.exception.VoException;
 @Slf4j
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 	private static final Map<Class<? extends JwtException>, ExceptionCode> JWT_EXCEPTION_CODE_MAP = Map.of(
-		ExpiredJwtException.class, ExceptionCode.EXPIRED_TOKEN,
+		ExpiredJwtException.class, ExceptionCode.EXPIRED_ACCESS_TOKEN,
 		MalformedJwtException.class, ExceptionCode.MALFORMED_TOKEN,
 		SignatureException.class, ExceptionCode.TAMPERED_TOKEN,
 		UnsupportedJwtException.class, ExceptionCode.UNSUPPORTED_JWT_TOKEN

--- a/src/test/java/one/colla/global/exception/ExceptionCodeTest.java
+++ b/src/test/java/one/colla/global/exception/ExceptionCodeTest.java
@@ -20,16 +20,4 @@ class ExceptionCodeTest {
 
 		assertThat(codes).hasSize(ExceptionCode.values().length);
 	}
-
-	@Test
-	@DisplayName("Message 는 중복되지 않는다.")
-	void testUniqueMessage() {
-		// given when
-		Set<String> messages = new HashSet<>();
-		for (ExceptionCode code : ExceptionCode.values()) {
-			messages.add(code.getMessage());
-		}
-
-		assertThat(messages).hasSize(ExceptionCode.values().length);
-	}
 }


### PR DESCRIPTION
## 📌 관련 이슈

- https://github.com/98OO/colla-backend/issues/89

## ✨ PR 세부 내용

**1️⃣ 기존에 AccessToken 만료와 RefreshToken에 대한 에러코드를 통일했던 것에서 둘을 구분하도록 변경**  
- 에러 메세지는 보안상의 이유로 통일했으며, 에러 코드를 통해서 만료 토큰의 종류를 구별합니다.

<img width="1113" alt="스크린샷 2024-06-28 오후 11 34 04" src="https://github.com/98OO/colla-backend/assets/70826982/200ad308-5f19-4ef0-8f3a-ef4add9d8627">
<img width="1113" alt="스크린샷 2024-06-28 오후 11 34 16" src="https://github.com/98OO/colla-backend/assets/70826982/e592c720-ea4f-4e60-9ccb-4339d91aad74">

<br/><br/>

**2️⃣ accessToken 만료 시한을 롤백**  
- 기존 이슈로 인해 임시로 연장했던 accessToken의 만료 시한을 기존 값으로 롤백합니다.

