### PR TITLE
채팅 메세지 조회시 생성 시간이 동일한 경우 순서가 보장되지 않는 문제 해결

### DIFF
--- a/src/main/java/one/colla/chat/domain/ChatChannelMessageRepository.java
+++ b/src/main/java/one/colla/chat/domain/ChatChannelMessageRepository.java
@@ -14,17 +14,17 @@ public interface ChatChannelMessageRepository extends JpaRepository<ChatChannelM
 
 	/**
 	 * 주어진 채팅 채널과 기준에 따라 채팅 메시지를 찾습니다.
-	 * 결과는 생성 날짜 기준 내림차순으로 정렬됩니다.
+	 * 결과는 생성 날짜(`createdAt`) 기준 내림차순으로 정렬되며, 동일한 생성 날짜를 가진 메시지들은 ID 기준으로 추가 정렬됩니다.
 	 *
 	 * @param chatChannel 채팅 메시지를 필터링할 채팅 채널
-	 * @param before 선택적 채팅 메시지 ID로, 이 채팅 메시지의 생성 날짜 이전에 생성된 채팅 메시지들을 필터링합니다
+	 * @param before 선택적 채팅 메시지 ID로, 이 ID에 해당하는 메시지의 생성 날짜 이전에 생성된 채팅 메시지들을 필터링합니다
 	 * @param pageable 페이징 정보
 	 * @return 주어진 기준에 맞는 채팅 메시지 목록
 	 */
 	@Query("SELECT msg FROM ChatChannelMessage msg WHERE msg.chatChannel = :chatChannel "
 		+ "AND (:before IS NULL "
 		+ "OR msg.createdAt < (SELECT bmsg.createdAt FROM ChatChannelMessage bmsg WHERE bmsg.id = :before)) "
-		+ "ORDER BY msg.createdAt DESC")
+		+ "ORDER BY msg.createdAt DESC, msg.id DESC")
 	List<ChatChannelMessage> findChatChannelMessageByChatChannelAndCriteria(
 		@Param("chatChannel") ChatChannel chatChannel,
 		@Param("before") @Nullable Long before,

--- a/src/test/java/one/colla/chat/domain/ChatChannelMessageRepositoryTest.java
+++ b/src/test/java/one/colla/chat/domain/ChatChannelMessageRepositoryTest.java
@@ -75,7 +75,7 @@ class ChatChannelMessageRepositoryTest extends RepositoryTest {
 	}
 
 	@Test
-	@DisplayName("채팅 메시지를 id 기준으로 내림차순으로 조회할 수 있다.")
+	@DisplayName("채팅 메시지를 생성 날짜 및 id 기준으로 내림차순으로 조회할 수 있다.")
 	void findChatChannelMessageByChatChannelAndCriteria_Success() {
 		// given
 		List<ChatChannelMessage> messages = new ArrayList<>();

--- a/src/test/java/one/colla/chat/domain/ChatChannelMessageRepositoryTest.java
+++ b/src/test/java/one/colla/chat/domain/ChatChannelMessageRepositoryTest.java
@@ -93,8 +93,11 @@ class ChatChannelMessageRepositoryTest extends RepositoryTest {
 
 		// then
 		assertThat(findMessages).hasSize(5);
-		assertThat(findMessages.get(0).getCreatedAt()).isAfterOrEqualTo(
-			findMessages.get(findMessages.size() - 1).getCreatedAt());
+		for (int i = 0; i < findMessages.size() - 1; i++) {
+			Long currentId = findMessages.get(i).getId();
+			Long nextId = findMessages.get(i + 1).getId();
+			assertThat(currentId).isGreaterThan(nextId);
+		}
 	}
 
 	@Test

--- a/src/test/java/one/colla/chat/domain/ChatChannelMessageRepositoryTest.java
+++ b/src/test/java/one/colla/chat/domain/ChatChannelMessageRepositoryTest.java
@@ -75,7 +75,7 @@ class ChatChannelMessageRepositoryTest extends RepositoryTest {
 	}
 
 	@Test
-	@DisplayName("채팅 메시지를 생성 날짜 기준 내림차순으로 조회할 수 있다.")
+	@DisplayName("채팅 메시지를 id 기준으로 내림차순으로 조회할 수 있다.")
 	void findChatChannelMessageByChatChannelAndCriteria_Success() {
 		// given
 		List<ChatChannelMessage> messages = new ArrayList<>();


### PR DESCRIPTION
## 📌 관련 이슈

- https://github.com/98OO/colla-backend/issues/94

## ✨ PR 세부 내용
- `createdAt`이 같은 메시지들에 대해 `id`를 추가적으로 내림차순 정렬하여 더 명확한 순서를 보장합니다. 
```java
@Query("SELECT msg FROM ChatChannelMessage msg WHERE msg.chatChannel = :chatChannel "
		+ "AND (:before IS NULL "
		+ "OR msg.createdAt < (SELECT bmsg.createdAt FROM ChatChannelMessage bmsg WHERE bmsg.id = :before)) "
		+ "ORDER BY msg.createdAt DESC, msg.id DESC")
```

## ✅ 리뷰 요구사항(선택)
- 궁금한 점 있으시면 댓글 남겨주세요!
