### PR TITLE
채팅 메시지 전송 시 문자열 양쪽 끝 공백 사라지는 문제

### DIFF
--- a/src/main/java/one/colla/chat/application/dto/request/ChatCreateRequest.java
+++ b/src/main/java/one/colla/chat/application/dto/request/ChatCreateRequest.java
@@ -10,7 +10,9 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import one.colla.chat.domain.ChatType;
+import one.colla.global.config.json.NoStrip;
 
+@NoStrip
 public record ChatCreateRequest(
 	@NotNull(message = "채팅 타입을 입력해주세요.")
 	ChatType chatType,

--- a/src/main/java/one/colla/global/config/json/ConditionalStringStripDeserializer.java
+++ b/src/main/java/one/colla/global/config/json/ConditionalStringStripDeserializer.java
@@ -1,0 +1,30 @@
+package one.colla.global.config.json;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+class ConditionalStringStripDeserializer extends JsonDeserializer<String> {
+	private final JsonDeserializer<String> defaultDeserializer = new StringStripJsonDeserializer();
+	private final JsonDeserializer<String> originalDeserializer = new JsonDeserializer<String>() {
+		@Override
+		public String deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+			return parser.getValueAsString();
+		}
+	};
+
+	@Override
+	public String deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+		if (shouldSkipStrip(parser)) {
+			return originalDeserializer.deserialize(parser, context);
+		}
+		return defaultDeserializer.deserialize(parser, context);
+	}
+
+	private boolean shouldSkipStrip(JsonParser parser) {
+		return parser.getCurrentValue() != null
+			&& parser.getCurrentValue().getClass().isAnnotationPresent(NoStrip.class);
+	}
+}

--- a/src/main/java/one/colla/global/config/json/JsonConfig.java
+++ b/src/main/java/one/colla/global/config/json/JsonConfig.java
@@ -4,7 +4,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 @Configuration
@@ -19,9 +23,17 @@ public class JsonConfig {
 
 	private SimpleModule customJsonDeserializeModule() {
 		SimpleModule module = new SimpleModule();
-		module.addDeserializer(String.class, new StringStripJsonDeserializer());
-
+		module.setDeserializerModifier(new BeanDeserializerModifier() {
+			@Override
+			public JsonDeserializer<?> modifyDeserializer(DeserializationConfig config,
+				BeanDescription beanDesc,
+				JsonDeserializer<?> deserializer) {
+				if (beanDesc.getBeanClass() == String.class) {
+					return new ConditionalStringStripDeserializer();
+				}
+				return deserializer;
+			}
+		});
 		return module;
 	}
 }
-

--- a/src/main/java/one/colla/global/config/json/NoStrip.java
+++ b/src/main/java/one/colla/global/config/json/NoStrip.java
@@ -1,0 +1,12 @@
+package one.colla.global.config.json;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// Strip 을 비활성화하기 위한 커스텀 어노테이션
+@Target({ElementType.FIELD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoStrip {
+}


### PR DESCRIPTION
## 📌 관련 이슈
-closed: https://github.com/98OO/colla-backend/issues/99

## ✨ PR 세부 내용
채팅 메시지 전송 시 문자열 양쪽 끝의 공백이 사라지는 문제를 해결했습니다.

- Jackson ObjectMapper의 String Deserialize 과정에서의 trim 동작을 제어하기 위한 컴포넌트들을 추가했습니다:
  - `@NoStrip`: trim 비활성화를 위한 어노테이션
  - `ConditionalStringStripDeserializer`: `@NoStrip` 어노테이션 유무에 따라 trim 적용을 결정하는 Deserializer
  - `JsonConfig`: 커스텀 Deserializer 등록을 위한 설정

- 채팅 메시지의 공백 보존을 위해 `ChatCreateRequest`에 `@NoStrip` 어노테이션을 적용했습니다.

## ✅ 리뷰 요구사항
1. String Deserialize 동작 변경에 따른 side effect가 없는지 검토 부탁드립니다.
2. 현재 구조에서 trim 동작을 제어하는 방식이 적절한지 의견 부탁드립니다.