### PR TITLE
자료수집 피드 응답 작성이 응답 마감시간 이후에도 가능하도록 변경

### DIFF
--- a/src/main/java/one/colla/feed/collect/application/CollectFeedService.java
+++ b/src/main/java/one/colla/feed/collect/application/CollectFeedService.java
@@ -19,7 +19,6 @@ import one.colla.feed.collect.domain.CollectFeedStatus;
 import one.colla.feed.common.application.FeedService;
 import one.colla.feed.common.application.dto.request.CommonCreateFeedRequest;
 import one.colla.feed.common.domain.FeedType;
-import one.colla.feed.common.util.DateTimeUtil;
 import one.colla.global.exception.CommonException;
 import one.colla.global.exception.ExceptionCode;
 import one.colla.teamspace.application.TeamspaceService;
@@ -116,13 +115,13 @@ public class CollectFeedService {
 		Teamspace teamspace = userTeamspace.getTeamspace();
 
 		CollectFeed feed = (CollectFeed)feedService.findFeedByTeamspaceAndType(teamspace, feedId, FeedType.COLLECT);
-		if (DateTimeUtil.isDeadlinePassed(feed.getDueAt())) {
-			log.warn(
-				"피드(자료수집 응답) 수정 시도 - 팀스페이스 Id: {}, 사용자 Id: {}, 피드 Id: {} (마감일이 지남)",
-				teamspaceId, userDetails.getUserId(), feedId
-			);
-			throw new CommonException(ExceptionCode.FORBIDDEN_ACTION_DEADLINE_PASSED);
-		}
+		// if (DateTimeUtil.isDeadlinePassed(feed.getDueAt())) {
+		// 	log.warn(
+		// 		"피드(자료수집 응답) 수정 시도 - 팀스페이스 Id: {}, 사용자 Id: {}, 피드 Id: {} (마감일이 지남)",
+		// 		teamspaceId, userDetails.getUserId(), feedId
+		// 	);
+		// 	throw new CommonException(ExceptionCode.FORBIDDEN_ACTION_DEADLINE_PASSED);
+		// }
 
 		Optional<CollectFeedResponse> optionalResponse = feed.getCollectFeedResponses().stream()
 			.filter(cfr -> cfr.getUser().getId().equals(userDetails.getUserId()))


### PR DESCRIPTION


## 📌 관련 이슈

- closed: https://github.com/98OO/colla-backend/issues/108

## ✨ PR 세부 내용

**자료수집 피드의 도메인 요구사항 변경에 따라 마감시간 이후에도 응답 작성이 가능하도록 수정했습니다.**

변경 사항:
- 자료수집 피드 응답 작성 시 마감시간 체크 로직 제거
- 관련 로그 및 예외처리(FORBIDDEN_ACTION_DEADLINE_PASSED) 코드 주석 처리

이 변경으로 사용자들은 마감시간과 관계없이 자료수집 피드에 응답을 작성할 수 있게 됩니다.
