### PR TITLE
/status API 성능 최적화 - 데이터베이스 쿼리 개선

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ logs/*
 
 ### application*.properties ###
 src/main/resources/*.properties
+
+### p6spy log ###
+spy.log

--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,9 @@ dependencies {
     /* visibility */
     implementation 'org.springframework.boot:spring-boot-starter-actuator:3.2.4'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.2'
+
 }
 
 tasks.register('copyPrivate', Copy) {

--- a/src/main/java/one/colla/global/config/log/P6SpyConfig.java
+++ b/src/main/java/one/colla/global/config/log/P6SpyConfig.java
@@ -1,0 +1,18 @@
+package one.colla.global.config.log;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class P6SpyConfig {
+
+	@Bean
+	public P6SpyEventListener p6SpyCustomEventListener() {
+		return new P6SpyEventListener();
+	}
+
+	@Bean
+	public P6SpyFormatter p6SpyCustomFormatter() {
+		return new P6SpyFormatter();
+	}
+}

--- a/src/main/java/one/colla/global/config/log/P6SpyEventListener.java
+++ b/src/main/java/one/colla/global/config/log/P6SpyEventListener.java
@@ -1,0 +1,15 @@
+package one.colla.global.config.log;
+
+import java.sql.SQLException;
+
+import com.p6spy.engine.common.ConnectionInformation;
+import com.p6spy.engine.event.JdbcEventListener;
+import com.p6spy.engine.spy.P6SpyOptions;
+
+public class P6SpyEventListener extends JdbcEventListener {
+
+	@Override
+	public void onAfterGetConnection(ConnectionInformation connectionInformation, SQLException ex) {
+		P6SpyOptions.getActiveInstance().setLogMessageFormat(P6SpyFormatter.class.getName());
+	}
+}

--- a/src/main/java/one/colla/global/config/log/P6SpyFormatter.java
+++ b/src/main/java/one/colla/global/config/log/P6SpyFormatter.java
@@ -1,0 +1,71 @@
+package one.colla.global.config.log;
+
+import java.util.Locale;
+import java.util.Set;
+
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+
+public class P6SpyFormatter implements MessageFormattingStrategy {
+
+	private static final String NEW_LINE = System.lineSeparator();
+	private static final String TAB = "\t";
+	private static final Set<String> DDL_KEYWORDS = Set.of("create", "alter", "drop", "comment");
+	private static final String CONNECTION_ID_FORMAT = "Connection ID: %s";
+	private static final String SEPARATOR = "-".repeat(200);
+
+	@Override
+	public String formatMessage(int connectionId, String now, long elapsed, String category, String prepared,
+		String sql, String url) {
+		if (sql.trim().isEmpty()) {
+			return formatByCommand(category, connectionId);
+		}
+		return formatBySql(sql, category) + formatAdditionalInfo(elapsed, connectionId);
+	}
+
+	private static String formatByCommand(String category, int connectionId) {
+		return String.format("%s | Category: %s", String.format(CONNECTION_ID_FORMAT, connectionId), category);
+	}
+
+	private String formatBySql(String sql, String category) {
+		String formattedSql = isStatementDdl(sql, category)
+			? formatDdl(sql)
+			: formatDml(sql);
+
+		return NEW_LINE + removeTimeZoneOffset(formattedSql);
+	}
+
+	private String formatDdl(String sql) {
+		return NEW_LINE + "Execute DDL : " + FormatStyle.DDL.getFormatter().format(sql);
+	}
+
+	private String formatDml(String sql) {
+		return NEW_LINE + "Execute DML : " + FormatStyle.BASIC.getFormatter().format(sql);
+	}
+
+	private String formatAdditionalInfo(long elapsed, int connectionId) {
+		return String.join(
+			NEW_LINE,
+			"",
+			"",
+			TAB + String.format(CONNECTION_ID_FORMAT, connectionId),
+			TAB + String.format("Execution Time: %s ms", elapsed),
+			"",
+			SEPARATOR
+		);
+	}
+
+	private boolean isStatementDdl(String sql, String category) {
+		return Category.STATEMENT.getName().equals(category) && isDdl(sql.trim().toLowerCase(Locale.ROOT));
+	}
+
+	private boolean isDdl(String lowerSql) {
+		return DDL_KEYWORDS.stream().anyMatch(lowerSql::startsWith);
+	}
+
+	private String removeTimeZoneOffset(String sql) {
+		return sql.replace("+0900", "");
+	}
+}

--- a/src/main/java/one/colla/teamspace/application/TeamspaceService.java
+++ b/src/main/java/one/colla/teamspace/application/TeamspaceService.java
@@ -1,7 +1,9 @@
 package one.colla.teamspace.application;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.context.ApplicationEventPublisher;
@@ -296,6 +298,15 @@ public class TeamspaceService {
 			InviteCode.of(generatedCode, userTeamspace.getTeamspace().getId(), validSeconds));
 
 		return Pair.of(inviteCode, userTeamspace);
+	}
+
+	@Transactional(readOnly = true)
+	public Map<Long, Long> countParticipantsByTeamspaceIds(List<Long> teamspaceIds) {
+		return teamspaceRepository.countParticipantsByTeamspaceIds(teamspaceIds).stream()
+			.collect(Collectors.toMap(
+				arr -> (Long)arr[0],  // 팀스페이스 ID
+				arr -> (Long)arr[1]   // 참여자 수
+			));
 	}
 
 	/**

--- a/src/main/java/one/colla/teamspace/domain/TeamspaceRepository.java
+++ b/src/main/java/one/colla/teamspace/domain/TeamspaceRepository.java
@@ -1,6 +1,16 @@
 package one.colla.teamspace.domain;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TeamspaceRepository extends JpaRepository<Teamspace, Long> {
+	@Query("SELECT t.id, COUNT(ut) "
+		+ "FROM Teamspace t "
+		+ "JOIN t.userTeamspaces ut "
+		+ "WHERE t.id IN :teamspaceIds "
+		+ "GROUP BY t.id")
+	List<Object[]> countParticipantsByTeamspaceIds(@Param("teamspaceIds") List<Long> teamspaceIds);
 }

--- a/src/main/java/one/colla/user/domain/UserRepository.java
+++ b/src/main/java/one/colla/user/domain/UserRepository.java
@@ -3,9 +3,17 @@ package one.colla.user.domain;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import one.colla.user.domain.vo.Email;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByEmail(Email email);
+
+	@Query("SELECT DISTINCT u FROM User u "
+		+ "LEFT JOIN FETCH u.userTeamspaces ut "
+		+ "LEFT JOIN FETCH ut.teamspace t "
+		+ "WHERE u.id = :userId")
+	Optional<User> findByIdWithTeamspaces(@Param("userId") Long userId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,13 +68,17 @@ spring:
   websocket:
     allowed-origins: http://localhost:8080, http://localhost:3000, ${BASE_URL}
 
-
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
   swagger-ui:
     url: /docs/open-api-3.0.1.yaml
     path: /swagger
+
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true
 
 jwt:
   secret-key:


### PR DESCRIPTION
## 📌 관련 이슈

- related: https://github.com/98OO/colla-backend/issues/123

## ✨ PR 세부 내용
사용자 정보 요청 API 내부 쿼리 성능을 개선합니다.

**1️⃣ `p6spy` 세팅**
-  실제 실행된 SQL 쿼리를 로컬 개발 환경에서 확인 할 수 있도록 세팅 진행

**2️⃣ 읽지 않은 채팅 개수 API 분리**
- 현재 status 조회 시 참가한 전체 팀 스페이스의 읽지 않은 채팅 개수를 같이 반환하고 있음
- 팀스페이스별로 읽지 않은 채팅 개수를 가져오는 기능을 분리하여 새로운 API 작성 필요 (예정, 현재는 임시값으로 대체)

**3️⃣ N+1 문제 개선**
 - 현재 API 호출 한번에 총  `2(N+1)`쿼리가 발생하고 있음
`사용자의 팀스페이스 목록 조회` -> `각 팀스페이스 정보 조회` -> `각 팀스페이스의 참여자 목록 조회`
-  페치 조인(Fetch Join)과 일괄 집계 쿼리를 도입해 총 2개의 쿼리만 실행되도록 개선 (대략 80% 이상의 쿼리 실행 단축)